### PR TITLE
feat: add points schema

### DIFF
--- a/1/points.json
+++ b/1/points.json
@@ -1,0 +1,13 @@
+[
+    {
+        "token": "0xbC4B4AC47582c3E38Ce5940B80Da65401F4628f1",
+        "name": "Euler points",
+        "description": "testing",
+        "logo": "euler.svg",
+        "url": "https://euler.finance",
+        "vaults": [
+            "0xbC4B4AC47582c3E38Ce5940B80Da65401F4628f1"
+        ],
+        "entity": "euler-dao"
+    }
+]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ Each entry in this object corresponds to a lending product, which is primarily a
 * `logo`: The filename of a logo stored in the `logo/` directory.
 * `vaults`: An array of the vault addresses (in checksumed hex format) that comprise the product. Each vault must exist in the `vaults.json` file.
 
+### `points.json`
+
+Each entry in this array corresponds to points available on deposits in a vault. Each item has the following
+
+* `token`: The token address (in a checksumed hex format) that the points are denominated in. (Required)
+* `name`: The name of the points, for example "Euler Points". (Required)
+* `description`: A long-form description of the points, displayed within points tooltips.
+* `url`: A URL where users can learn more about the points.
+* `logo`: The filename of a logo stored in the `logo/` directory. (Required)
+* `vaults`: An array of the vault addresses (in checksumed hex format) that offer these points. Each vault does not need to exist in the `vaults.json` file. (Required)
+* `entity`: An entity ID that refers to the organisation responsible for governing and/or creating this vault, or a list of entity IDs if the vault is joint-managed.
 
 ## Logos
 

--- a/verify.js
+++ b/verify.js
@@ -40,6 +40,7 @@ function validateChain(chainId) {
     let entities = loadJsonFile(`${chainId}/entities.json`);
     let vaults = loadJsonFile(`${chainId}/vaults.json`);
     let products = loadJsonFile(`${chainId}/products.json`);
+    let points = loadJsonFile(`${chainId}/points.json`);
 
     for (let entityId of Object.keys(entities)) {
         let entity = entities[entityId];
@@ -84,9 +85,23 @@ function validateChain(chainId) {
         if (product.logo && !logos[product.logo]) throw Error(`products: logo not found: ${product.logo}`);
     }
 
+    for(const point of points) {
+        if (point.token !== ethers.getAddress(point.token)) throw Error(`points: malformed token: ${point.token}`);
+        if (!point.name) throw Error(`points: missing name: ${point.name}`);
+        if (point.url && !validUrl(point.url)) throw Error(`points: missing name: ${point.name}`);
+        if (point.logo && !logos[point.logo]) throw Error(`points: logo not found: ${product.logo}`);
+        for (let addr of point.vaults) {
+            if (addr !== ethers.getAddress(addr)) throw Error(`points: malformed vault address: ${addr}`);
+        }
+        for (let entity of getArray(point.entity)) {
+            if (!entities[entity]) throw Error(`points: no such entity ${entity}`);
+        }
+    }
+
     checkFormatting(`${chainId}/entities.json`);
     checkFormatting(`${chainId}/vaults.json`);
     checkFormatting(`${chainId}/products.json`);
+    checkFormatting(`${chainId}/points.json`);
 }
 
 function loadJsonFile(file) {
@@ -95,6 +110,10 @@ function loadJsonFile(file) {
 
 function validSlug(slug) {
     return /^[a-z0-9-]+$/.test(slug);
+}
+
+function validUrl(url) {
+    return /^(https?:\/\/)?([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,63}(\/[^\s]*)?$/.test(url);
 }
 
 function getArray(v) {


### PR DESCRIPTION
Create schema for points 

### `points.json`

Each entry in this array corresponds to points available on deposits in a vault. Each item has the following

* `token`: The token address (in a checksumed hex format) that the points are denominated in. (Required)
* `name`: The name of the points, for example "Euler Points". (Required)
* `description`: A long-form description of the points, displayed within points tooltips.
* `url`: A URL where users can learn more about the points.
* `logo`: The filename of a logo stored in the `logo/` directory. (Required)
* `vaults`: An array of the vault addresses (in checksumed hex format) that offer these points. Each vault does not need to exist in the `vaults.json` file. (Required)
* `entity`: An entity ID that refers to the organisation responsible for governing and/or creating this vault, or a list of entity IDs if the vault is joint-managed.
