### PR TITLE
chore: add fix script

### DIFF
--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -1,0 +1,47 @@
+name: Fix Ethereum Addresses and Formatting
+
+on:
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Fix addresses and formatting
+        run: npm run fix
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'fix: normalize ethereum addresses and fix biome formatting'
+          title: 'fix: normalize ethereum addresses and fix biome formatting'
+          body: |
+            This PR normalizes Ethereum addresses and fixes Biome formatting issues across all chain files.
+            
+            Changes made:
+            - Normalized checksum addresses in entities.json
+            - Normalized checksum addresses in vaults.json
+            - Normalized checksum addresses in products.json
+            - Normalized checksum addresses in points.json
+            - Fixed Biome formatting issues (trailing commas, spacing)
+            
+            This is an automated PR created by the fix workflow.
+          branch: fix/addresses-and-formatting
+          delete-branch: true
+          labels: |
+            automated

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ Logos exist in the `logo/` directory, and should satisfy the following propertie
 * SVG format
 * Square-shaped
 
+## Scripts
 
+The repository includes several npm scripts to help maintain the data:
+
+* `npm run verify`: Validates all JSON files against their schemas and ensures all Ethereum addresses are properly checksummed.
+* `npm run fix`: Normalizes all Ethereum addresses to their proper checksummed format and fixes Biome formatting issues (like trailing commas) across all chain files.
 
 ## Verification
 

--- a/fix.js
+++ b/fix.js
@@ -1,0 +1,179 @@
+const fs = require("node:fs");
+const { getAddress } = require("ethers");
+
+// Get all chain directories
+const chainDirs = fs.readdirSync(".").filter((dir) => /^\d+$/.test(dir));
+
+function fixAddress(address) {
+	try {
+		return getAddress(address);
+	} catch (error) {
+		throw Error(`Invalid address ${address}: ${error.message}`);
+	}
+}
+
+function fixAddressesInArray(addresses, context) {
+	return addresses.map((address) => {
+		const fixedAddress = fixAddress(address);
+		if (fixedAddress !== address) {
+			return {
+				changed: true,
+				message: `Fixing ${context}: ${address} -> ${fixedAddress}`,
+				value: fixedAddress,
+			};
+		}
+		return { changed: false, value: address };
+	});
+}
+
+function fixAddressesInObject(obj, context) {
+	const result = {};
+	let changes = false;
+	const changesList = [];
+
+	for (const [key, value] of Object.entries(obj)) {
+		const fixedKey = fixAddress(key);
+		if (fixedKey !== key) {
+			changes = true;
+			const message = `Fixing ${context}: ${key} -> ${fixedKey}`;
+			console.log(message);
+			changesList.push(message);
+		}
+		result[fixedKey] = value;
+	}
+
+	return { result, changes, changesList };
+}
+
+function fixBiomeFormatting(content) {
+	// Remove trailing commas in arrays and objects
+	let fixed = content.replace(/,(\s*[}\]])/g, "$1");
+
+	// Ensure consistent spacing around colons in objects, but not in URLs
+	fixed = fixed.replace(/([^"\s]):(?=\s*[{"])/g, "$1 :");
+
+	// Ensure consistent spacing around commas
+	fixed = fixed.replace(/,(\S)/g, ", $1");
+
+	return fixed;
+}
+
+function fixChain(chainId) {
+	console.log(`\nProcessing chain ${chainId}...`);
+
+	// Read all JSON files
+	const files = {
+		entities: JSON.parse(fs.readFileSync(`${chainId}/entities.json`, "utf8")),
+		vaults: JSON.parse(fs.readFileSync(`${chainId}/vaults.json`, "utf8")),
+		points: JSON.parse(fs.readFileSync(`${chainId}/points.json`, "utf8")),
+		products: JSON.parse(fs.readFileSync(`${chainId}/products.json`, "utf8")),
+	};
+
+	let changes = false;
+	const changesList = [];
+
+	// Fix entity addresses
+	for (const [entityId, entity] of Object.entries(files.entities)) {
+		if (entity.addresses) {
+			const {
+				result,
+				changes: entityChanges,
+				changesList: entityChangesList,
+			} = fixAddressesInObject(entity.addresses, `entities.${entityId}`);
+			if (entityChanges) {
+				changes = true;
+				changesList.push(...entityChangesList);
+				entity.addresses = result;
+			}
+		}
+	}
+
+	// Fix vault addresses
+	const {
+		result: fixedVaults,
+		changes: vaultChanges,
+		changesList: vaultChangesList,
+	} = fixAddressesInObject(files.vaults, "vault");
+	if (vaultChanges) {
+		changes = true;
+		changesList.push(...vaultChangesList);
+		files.vaults = fixedVaults;
+	}
+
+	// Fix product vault addresses
+	for (const [productId, product] of Object.entries(files.products)) {
+		if (product.vaults) {
+			const fixedAddresses = fixAddressesInArray(
+				product.vaults,
+				`vault address in products.${productId}`,
+			);
+			const productChanges = fixedAddresses.filter((a) => a.changed);
+			if (productChanges.length > 0) {
+				changes = true;
+				changesList.push(...productChanges.map((a) => a.message));
+				product.vaults = fixedAddresses.map((a) => a.value);
+			}
+		}
+	}
+
+	// Fix points addresses
+	for (const point of files.points) {
+		if (point.skipValidation) continue;
+
+		if (point.token) {
+			const fixedToken = fixAddress(point.token);
+			if (fixedToken !== point.token) {
+				changes = true;
+				const message = `Fixing token address in points.${point.name}: ${point.token} -> ${fixedToken}`;
+				console.log(message);
+				changesList.push(message);
+				point.token = fixedToken;
+			}
+		}
+
+		for (const field of ["collateralVaults", "liabilityVaults"]) {
+			if (point[field]) {
+				const fixedAddresses = fixAddressesInArray(
+					point[field],
+					`${field} address in points.${point.name}`,
+				);
+				const pointChanges = fixedAddresses.filter((a) => a.changed);
+				if (pointChanges.length > 0) {
+					changes = true;
+					changesList.push(...pointChanges.map((a) => a.message));
+					point[field] = fixedAddresses.map((a) => a.value);
+				}
+			}
+		}
+	}
+
+	// Write back changes if any were made
+	if (changes) {
+		console.log(`\nWriting changes for chain ${chainId}:`);
+		console.log(`Found ${changesList.length} addresses to fix`);
+
+		// Write all files with Biome formatting
+		for (const [filename, data] of Object.entries(files)) {
+			const content = JSON.stringify(data, null, 2);
+			const biomeFixed = fixBiomeFormatting(content);
+			fs.writeFileSync(`${chainId}/${filename}.json`, biomeFixed);
+			console.log(`- Updated ${filename}.json`);
+		}
+
+		console.log(`\nAll changes saved for chain ${chainId}`);
+	} else {
+		console.log(`No malformed addresses found in chain ${chainId}`);
+	}
+}
+
+// Process all chains
+for (const chainId of chainDirs) {
+	try {
+		fixChain(chainId);
+	} catch (error) {
+		console.error(`Error processing chain ${chainId}:`, error);
+		process.exit(1);
+	}
+}
+
+console.log("\nAddress fixing complete!");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+	"name": "euler-labels",
+	"version": "1.0.0",
 	"scripts": {
+		"verify": "node verify.js",
+		"fix": "node fix.js && npm run biome:fix",
 		"biome:fix": "biome check --write",
 		"prepare": "husky install",
 		"biome": "biome check"
@@ -10,7 +14,8 @@
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.0",
-		"husky": "^9.1.6"
+		"husky": "^9.1.6",
+		"viem": "^2.7.9"
 	},
 	"lint-staged": {
 		"*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [


### PR DESCRIPTION
Adds `fix.js` script and GitHub workflow to:
- Normalize Ethereum addresses to checksum format
- Fix Biome formatting (trailing commas, spacing)
- Create PRs with changes

Usage: 
- Trigger workflow manually from GitHub Actions tab
- Or, run `npm run fix`

![CleanShot 2025-04-02 at 09 41 09@2x](https://github.com/user-attachments/assets/c388770a-c6ee-4d3a-95f3-a4802f64062a)
![CleanShot 2025-04-02 at 09 41 41@2x](https://github.com/user-attachments/assets/9dca14c8-da3e-435d-ae66-9d191c71ad57)
