### PR TITLE
update multipliers for sonic season 2

### DIFF
--- a/146/points.json
+++ b/146/points.json
@@ -1,116 +1,71 @@
 [
 	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x4c0AF5d6Bcb10B3C05FB5F3a846999a3d87534C7"],
-		"entity": ["re7-labs"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x2De851E60e428106fC98fE94017466F8D71793d1"],
-		"entity": ["re7-labs"]
-	},
-	{
-		"name": "12x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x3D9e5462A940684073EED7e4a13d19AE0Dcd13bc"],
-		"entity": ["re7-labs"]
-	},
-	{
-		"name": "12x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0xeEb1DC1Ca7ffC5b54aD1cc4c1088Db4E5657Cb6c"],
-		"entity": ["re7-labs"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0xEeb63D2d370C5318ef174D366A41507F9380f093"],
-		"entity": ["re7-labs"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0xF3c631B979EB59d8333374baA7c58B5Aff5e24D2"],
-		"entity": ["re7-labs"]
-	},
-	{
 		"name": "4x Sonic Points",
+		"logo": "sonic.png",
+		"collateralVaults": [
+			"0x4c0AF5d6Bcb10B3C05FB5F3a846999a3d87534C7",
+			"0x2De851E60e428106fC98fE94017466F8D71793d1",
+			"0xEeb63D2d370C5318ef174D366A41507F9380f093",
+			"0xF3c631B979EB59d8333374baA7c58B5Aff5e24D2"
+		],
+		"entity": ["re7-labs"]
+	},
+	{
+		"name": "6x Sonic Points",
+		"logo": "sonic.png",
+		"collateralVaults": [
+			"0x3D9e5462A940684073EED7e4a13d19AE0Dcd13bc",
+			"0xeEb1DC1Ca7ffC5b54aD1cc4c1088Db4E5657Cb6c"
+		],
+		"entity": ["re7-labs"]
+	},
+	{
+		"name": "2x Sonic Points",
 		"logo": "sonic.png",
 		"collateralVaults": ["0x2ad7546A19eb5D5eDb37EC88A4775995078d1CAd"],
 		"entity": ["re7-labs"]
 	},
 	{
-		"name": "4x Sonic Points",
+		"name": "2x Sonic Points",
 		"logo": "sonic.png",
 		"collateralVaults": ["0xa5cd24d9792F4F131f5976Af935A505D19c8Db2b"],
 		"entity": ["mev-capital"]
 	},
 	{
-		"name": "12x Sonic Points",
+		"name": "6x Sonic Points",
 		"logo": "sonic.png",
-		"collateralVaults": ["0x196F3C7443E940911EE2Bb88e019Fd71400349D9"],
+		"collateralVaults": [
+			"0x196F3C7443E940911EE2Bb88e019Fd71400349D9",
+			"0xB38D431e932fEa77d1dF0AE0dFE4400c97e597B8",
+			"0x1cDA7E7B2023C3f3c94Aa1999937358fA9D01Aab"
+		],
 		"entity": ["mev-capital"]
 	},
 	{
-		"name": "8x Sonic Points",
+		"name": "4x Sonic Points",
 		"logo": "sonic.png",
-		"collateralVaults": ["0x0806af1762Bdd85B167825ab1a64E31CF9497038"],
+		"collateralVaults": [
+			"0x0806af1762Bdd85B167825ab1a64E31CF9497038",
+			"0x05d57366B862022F76Fe93316e81E9f24218bBfC",
+			"0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A",
+			"0xeeaaB5c863f4b1c5356aF138F384AdC25Cb70Da6",
+			"0x6f2Ab32A6487A2996c74Ed2b173dFDF3d5EEDB58"
+		],
 		"entity": ["mev-capital"]
 	},
 	{
-		"name": "12x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0xB38D431e932fEa77d1dF0AE0dFE4400c97e597B8"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x05d57366B862022F76Fe93316e81E9f24218bBfC"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "12x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x1cDA7E7B2023C3f3c94Aa1999937358fA9D01Aab"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x9144C0F0614dD0acE859C61CC37e5386d2Ada43A"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0xeeaaB5c863f4b1c5356aF138F384AdC25Cb70Da6"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x6f2Ab32A6487A2996c74Ed2b173dFDF3d5EEDB58"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
+		"name": "4x Sonic Points",
 		"logo": "sonic.png",
 		"collateralVaults": ["0x1E1482E7Bc32cD085d7aF61F29019Ba372B63277"],
 		"entity": ["mev-capital"]
 	},
 	{
-		"name": "8x Sonic Points",
+		"name": "4x Sonic Points",
 		"logo": "sonic.png",
-		"collateralVaults": ["0x90a804D316A06E00755444D56b9eF52e5C4F4D73"],
-		"entity": ["mev-capital"]
-	},
-	{
-		"name": "8x Sonic Points",
-		"logo": "sonic.png",
-		"collateralVaults": ["0x6832F3090867449c058e1e3088E552E12AB18F9E"],
+		"collateralVaults": [
+			"0x90a804D316A06E00755444D56b9eF52e5C4F4D73",
+			"0x6832F3090867449c058e1e3088E552E12AB18F9E"
+		],
 		"entity": ["mev-capital"]
 	},
 	{


### PR DESCRIPTION
Updated the points multipliers for Sonic Season 2. Here are the details from their [docs](https://docs.soniclabs.com/funding/sonic-airdrop/sonic-points-season-1#whitelisted-assets). 

@theanxy can you check vault `0x1E1482E7Bc32cD085d7aF61F29019Ba372B63277` which is listed under mev-capital in the 'points.json' but is not referenced in 'points.json' and hence comes off as 'Ungoverned'. 