### PR TITLE
feat: hexagate sync pipeline driven by products.json

### DIFF
--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -42,9 +42,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Verify data
         run: node verify.js
@@ -69,8 +70,27 @@ jobs:
         env:
           HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
 
+      - name: Build failure comment
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "# Hexagate sync — failed"
+            echo ""
+            echo "Workflow run failed. See [the run logs]($RUN_URL) for details."
+            if [ -s sync-output.md ]; then
+              echo ""
+              echo "<details><summary>Partial output</summary>"
+              echo ""
+              cat sync-output.md
+              echo ""
+              echo "</details>"
+            fi
+          } > sync-output.md
+
       - name: Comment PR with diff
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: hexagate-sync

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -1,0 +1,51 @@
+name: Sync Hexagate
+
+on:
+  pull_request:
+    branches:
+      - master
+      - development
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: hexagate-sync-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify data
+        run: node verify.js
+
+      - name: Run Hexagate sync
+        run: |
+          node hexagate-sync.js \
+            ${{ github.event_name == 'pull_request' && '--dry-run' || '--apply' }} \
+            > sync-output.md
+        env:
+          HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
+
+      - name: Comment PR with diff
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: hexagate-sync
+          path: sync-output.md

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -8,6 +8,21 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Run mode"
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - apply
+      only:
+        description: "Optional comma-separated chainId list (leave blank for all chains)"
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: hexagate-sync-${{ github.ref }}
@@ -34,11 +49,23 @@ jobs:
       - name: Verify data
         run: node verify.js
 
-      - name: Run Hexagate sync
+      - name: Resolve sync mode
+        id: mode
         run: |
-          node hexagate-sync.js \
-            ${{ github.event_name == 'pull_request' && '--dry-run' || '--apply' }} \
-            > sync-output.md
+          case "${{ github.event_name }}" in
+            pull_request)     mode="--dry-run" ;;
+            push)             mode="--apply" ;;
+            workflow_dispatch) mode="--${{ github.event.inputs.mode }}" ;;
+            *)                mode="--dry-run" ;;
+          esac
+          only=""
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.only }}" ]; then
+            only="--only=${{ github.event.inputs.only }}"
+          fi
+          echo "args=${mode} ${only}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Hexagate sync
+        run: node hexagate-sync.js ${{ steps.mode.outputs.args }} > sync-output.md
         env:
           HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
 
@@ -48,3 +75,17 @@ jobs:
         with:
           header: hexagate-sync
           path: sync-output.md
+
+      - name: Upload sync summary
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-output
+          path: sync-output.md
+
+      - name: Append sync summary to job summary
+        if: always()
+        run: |
+          if [ -f sync-output.md ]; then
+            cat sync-output.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -27,10 +27,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Verify data
         run: node verify.js

--- a/hexagate-sync.js
+++ b/hexagate-sync.js
@@ -22,6 +22,10 @@ async function main() {
 
 	const http = createClient(apiKey);
 
+	log("Fetching Hexagate chain registry…");
+	const supportedChains = await fetchSupportedChains(http);
+	log(`Found ${supportedChains.size} monitorable chains`);
+
 	log("Fetching kind=1 tag inventory…");
 	const allTags = await fetchAllAddressTags(http);
 	const byName = new Map(allTags.map((t) => [t.name, t]));
@@ -57,10 +61,23 @@ async function main() {
 
 	const plan = [];
 	for (const chainId of chainDirs) {
-		const chainTag = discoverChainTag(allTags, chainId);
 		const desired = readDesiredVaults(chainId);
 		const current = govByChain.get(chainId) ?? new Set();
 
+		if (!supportedChains.has(chainId)) {
+			plan.push({
+				chainId,
+				skipped: "chain not supported by Hexagate (not monitorable)",
+				desired,
+				current,
+				toAdd: new Set(),
+				toRemove: current,
+				chainTag: null,
+			});
+			continue;
+		}
+
+		const chainTag = discoverChainTag(allTags, chainId);
 		if (!chainTag) {
 			plan.push({
 				chainId,
@@ -90,7 +107,6 @@ async function main() {
 
 	if (args.mode === "apply") {
 		for (const entry of plan) {
-			if (entry.skipped) continue;
 			if (entry.toAdd.size > 0) {
 				await applyAdds(http, entry, govVault);
 			}
@@ -182,6 +198,21 @@ function createClient(apiKey) {
 		post: (path, body, query) => request("POST", path, { body, query }),
 		delete: (path, query) => request("DELETE", path, { query }),
 	};
+}
+
+async function fetchSupportedChains(http) {
+	const res = await http.get("/api/v1/chains/");
+	const out = new Set();
+	for (const [k, info] of Object.entries(res ?? {})) {
+		const cid = Number(k);
+		if (!Number.isFinite(cid) || cid <= 0) continue;
+		if (info?.chain_type !== "evm") continue;
+		if (!info?.concord_support) continue;
+		if (!info?.included_in_plan) continue;
+		if (info?.is_testnet) continue;
+		out.add(cid);
+	}
+	return out;
 }
 
 async function fetchAllAddressTags(http) {
@@ -308,25 +339,21 @@ function renderSummary(plan, mode) {
 	let totalRemove = 0;
 	for (const e of plan) {
 		const status = e.skipped ? `skipped: ${e.skipped}` : "ok";
-		const add = e.skipped ? "—" : String(e.toAdd.size);
-		const rem = e.skipped ? "—" : String(e.toRemove.size);
 		lines.push(
-			`| ${e.chainId} | ${e.desired.size} | ${e.current.size} | ${add} | ${rem} | ${status} |`,
+			`| ${e.chainId} | ${e.desired.size} | ${e.current.size} | ${e.toAdd.size} | ${e.toRemove.size} | ${status} |`,
 		);
-		if (!e.skipped) {
-			totalAdd += e.toAdd.size;
-			totalRemove += e.toRemove.size;
-		}
+		totalAdd += e.toAdd.size;
+		totalRemove += e.toRemove.size;
 	}
 	lines.push(`| **total** |  |  | **${totalAdd}** | **${totalRemove}** |  |`);
 	lines.push("");
 
 	for (const e of plan) {
-		if (e.skipped) continue;
 		if (e.toAdd.size === 0 && e.toRemove.size === 0) continue;
-		lines.push(
-			`<details><summary>chain ${e.chainId}: +${e.toAdd.size} / -${e.toRemove.size}</summary>`,
-		);
+		const heading = e.skipped
+			? `chain ${e.chainId}: cleanup -${e.toRemove.size} (${e.skipped})`
+			: `chain ${e.chainId}: +${e.toAdd.size} / -${e.toRemove.size}`;
+		lines.push(`<details><summary>${heading}</summary>`);
 		lines.push("");
 		if (e.toAdd.size > 0) {
 			lines.push("**Add:**");
@@ -346,10 +373,14 @@ function renderSummary(plan, mode) {
 
 	const skipped = plan.filter((e) => e.skipped);
 	if (skipped.length > 0) {
-		lines.push("**Skipped chains:**");
+		lines.push("**Skipped chains (no sync):**");
 		lines.push("");
 		for (const e of skipped) {
-			lines.push(`- \`${e.chainId}\` — ${e.skipped}`);
+			const cleanup =
+				e.toRemove.size > 0
+					? ` — cleaning up ${e.toRemove.size} stale entry(ies)`
+					: "";
+			lines.push(`- \`${e.chainId}\` — ${e.skipped}${cleanup}`);
 		}
 		lines.push("");
 	}

--- a/hexagate-sync.js
+++ b/hexagate-sync.js
@@ -9,6 +9,9 @@ const TAG_PAGE_SIZE = 300;
 const ENTITY_RESOLVE_PAGE_SIZE = 200;
 const ADD_BATCH_SIZE = 50;
 const DELETE_BATCH_SIZE = 100;
+const REQUEST_TIMEOUT_MS = 30_000;
+const REQUEST_MAX_RETRIES = 2;
+const REQUEST_RETRY_BASE_MS = 1_000;
 
 main().catch((err) => {
 	process.stderr.write(`ERROR: ${err.stack || err.message || err}\n`);
@@ -183,14 +186,43 @@ function createClient(apiKey) {
 			init.headers["Content-Type"] = "application/json";
 			init.body = JSON.stringify(body);
 		}
-		const res = await fetch(url, init);
-		if (!res.ok) {
-			const text = await res.text();
-			throw Error(`${method} ${path} → HTTP ${res.status}: ${text}`);
+
+		let lastErr = null;
+		for (let attempt = 0; attempt <= REQUEST_MAX_RETRIES; attempt++) {
+			try {
+				const res = await fetch(url, {
+					...init,
+					signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+				});
+				if (res.status >= 500 && attempt < REQUEST_MAX_RETRIES) {
+					const text = await res.text();
+					lastErr = Error(`${method} ${path} → HTTP ${res.status}: ${text}`);
+					log(
+						`retry ${attempt + 1}/${REQUEST_MAX_RETRIES}: ${method} ${path} (HTTP ${res.status})`,
+					);
+					await sleep(REQUEST_RETRY_BASE_MS * 2 ** attempt);
+					continue;
+				}
+				if (!res.ok) {
+					const text = await res.text();
+					throw Error(`${method} ${path} → HTTP ${res.status}: ${text}`);
+				}
+				if (res.status === 204) return null;
+				const ct = res.headers.get("content-type") || "";
+				return ct.includes("application/json") ? res.json() : res.text();
+			} catch (err) {
+				if (attempt < REQUEST_MAX_RETRIES && isTransient(err)) {
+					lastErr = err;
+					log(
+						`retry ${attempt + 1}/${REQUEST_MAX_RETRIES}: ${method} ${path} (${err.message || err})`,
+					);
+					await sleep(REQUEST_RETRY_BASE_MS * 2 ** attempt);
+					continue;
+				}
+				throw err;
+			}
 		}
-		if (res.status === 204) return null;
-		const ct = res.headers.get("content-type") || "";
-		return ct.includes("application/json") ? res.json() : res.text();
+		throw lastErr;
 	}
 
 	return {
@@ -239,15 +271,25 @@ function normalizeEntitiesByChain(ebc) {
 }
 
 function discoverChainTag(allTags, chainId) {
-	let best = null;
+	const candidates = [];
 	for (const t of allTags) {
 		const ebc = t.entities_by_chain ?? {};
 		const keys = Object.keys(ebc).map(Number);
 		if (keys.length !== 1 || keys[0] !== chainId) continue;
-		const n = ebc[String(chainId)].length;
-		if (!best || n > best.n) best = { tag: t, n };
+		candidates.push({ tag: t, n: ebc[String(chainId)].length });
 	}
-	return best?.tag ?? null;
+	if (candidates.length === 0) return null;
+	candidates.sort((a, b) => b.n - a.n);
+	if (candidates.length > 1) {
+		const others = candidates
+			.slice(1)
+			.map((c) => `${c.tag.name}=${c.n}`)
+			.join(", ");
+		log(
+			`chain ${chainId}: ${candidates.length} candidate per-chain tags, picking '${candidates[0].tag.name}' (${candidates[0].n}) over [${others}]`,
+		);
+	}
+	return candidates[0].tag;
 }
 
 function readDesiredVaults(chainId) {
@@ -390,4 +432,21 @@ function renderSummary(plan, mode) {
 
 function log(msg) {
 	process.stderr.write(`${msg}\n`);
+}
+
+function sleep(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransient(err) {
+	if (!err) return false;
+	if (err.name === "TimeoutError" || err.name === "AbortError") return true;
+	const code = err.cause?.code ?? err.code;
+	return (
+		code === "ECONNRESET" ||
+		code === "ETIMEDOUT" ||
+		code === "ECONNREFUSED" ||
+		code === "EAI_AGAIN" ||
+		code === "ENOTFOUND"
+	);
 }

--- a/hexagate-sync.js
+++ b/hexagate-sync.js
@@ -1,0 +1,362 @@
+const fs = require("node:fs");
+
+const API_BASE = "https://api.hexagate.com";
+const GOV_VAULT_TAG_NAME = "GOV-Vault";
+const TAG_KIND_ADDRESS = 1;
+const ENTITY_TYPE_CONTRACT = 1;
+const ENTITY_PARAM_TYPE = 1;
+const TAG_PAGE_SIZE = 300;
+const ENTITY_RESOLVE_PAGE_SIZE = 200;
+const ADD_BATCH_SIZE = 50;
+const DELETE_BATCH_SIZE = 100;
+
+main().catch((err) => {
+	process.stderr.write(`ERROR: ${err.stack || err.message || err}\n`);
+	process.exit(1);
+});
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	const apiKey = process.env.HEXAGATE_API_KEY;
+	if (!apiKey) throw Error("HEXAGATE_API_KEY env var is required");
+
+	const http = createClient(apiKey);
+
+	log("Fetching kind=1 tag inventory…");
+	const allTags = await fetchAllAddressTags(http);
+	const byName = new Map(allTags.map((t) => [t.name, t]));
+	const govVault = byName.get(GOV_VAULT_TAG_NAME);
+	if (!govVault) {
+		throw Error(
+			`'${GOV_VAULT_TAG_NAME}' tag not found in Hexagate; refusing to proceed`,
+		);
+	}
+	log(`Found GOV-Vault tag id=${govVault.id}`);
+
+	log("Fetching current GOV-Vault membership…");
+	const govSnapshot = await http.get(
+		`/api/v1/monitoring/monitor_tags/${govVault.id}`,
+	);
+	const govByChain = normalizeEntitiesByChain(govSnapshot.entities_by_chain);
+
+	const chainDirs = fs
+		.readdirSync(".")
+		.filter((d) => /^\d+$/.test(d))
+		.map((d) => Number(d))
+		.filter((d) => !args.only || args.only.has(d))
+		.sort((a, b) => a - b);
+
+	if (args.only) {
+		const missing = [...args.only].filter((c) => !chainDirs.includes(c));
+		if (missing.length > 0) {
+			throw Error(
+				`--only references chains with no labels directory: ${missing.join(", ")}`,
+			);
+		}
+	}
+
+	const plan = [];
+	for (const chainId of chainDirs) {
+		const chainTag = discoverChainTag(allTags, chainId);
+		const desired = readDesiredVaults(chainId);
+		const current = govByChain.get(chainId) ?? new Set();
+
+		if (!chainTag) {
+			plan.push({
+				chainId,
+				skipped:
+					"no per-chain tag in Hexagate (no monitor configured for this chain)",
+				desired,
+				current,
+				toAdd: new Set(),
+				toRemove: new Set(),
+				chainTag: null,
+			});
+			continue;
+		}
+
+		const toAdd = setDiff(desired, current);
+		const toRemove = setDiff(current, desired);
+		plan.push({
+			chainId,
+			skipped: null,
+			desired,
+			current,
+			toAdd,
+			toRemove,
+			chainTag,
+		});
+	}
+
+	if (args.mode === "apply") {
+		for (const entry of plan) {
+			if (entry.skipped) continue;
+			if (entry.toAdd.size > 0) {
+				await applyAdds(http, entry, govVault);
+			}
+			if (entry.toRemove.size > 0) {
+				await applyRemoves(http, entry);
+			}
+		}
+	}
+
+	process.stdout.write(renderSummary(plan, args.mode));
+}
+
+function parseArgs(argv) {
+	let mode = null;
+	let only = null;
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i];
+		if (a === "--dry-run" || a === "--apply") {
+			if (mode) throw Error("specify exactly one of --dry-run or --apply");
+			mode = a === "--dry-run" ? "dry-run" : "apply";
+		} else if (a === "--only") {
+			const next = argv[++i];
+			if (!next) throw Error("--only requires a comma-separated chainId list");
+			only = new Set(
+				next.split(",").map((s) => {
+					const n = Number(s.trim());
+					if (!Number.isInteger(n) || n <= 0) {
+						throw Error(`--only: invalid chainId: ${s}`);
+					}
+					return n;
+				}),
+			);
+		} else if (a.startsWith("--only=")) {
+			only = new Set(
+				a
+					.slice("--only=".length)
+					.split(",")
+					.map((s) => {
+						const n = Number(s.trim());
+						if (!Number.isInteger(n) || n <= 0) {
+							throw Error(`--only: invalid chainId: ${s}`);
+						}
+						return n;
+					}),
+			);
+		} else {
+			throw Error(`unknown argument: ${a}`);
+		}
+	}
+	if (!mode) throw Error("specify exactly one of --dry-run or --apply");
+	return { mode, only };
+}
+
+function createClient(apiKey) {
+	const headers = {
+		"X-Hexagate-Api-Key": apiKey,
+		Accept: "application/json",
+	};
+
+	async function request(method, path, { query, body } = {}) {
+		const url = new URL(API_BASE + path);
+		if (query) {
+			for (const [k, v] of Object.entries(query)) {
+				if (v === undefined || v === null) continue;
+				if (Array.isArray(v)) {
+					for (const item of v) url.searchParams.append(k, String(item));
+				} else {
+					url.searchParams.set(k, String(v));
+				}
+			}
+		}
+		const init = { method, headers: { ...headers } };
+		if (body !== undefined) {
+			init.headers["Content-Type"] = "application/json";
+			init.body = JSON.stringify(body);
+		}
+		const res = await fetch(url, init);
+		if (!res.ok) {
+			const text = await res.text();
+			throw Error(`${method} ${path} → HTTP ${res.status}: ${text}`);
+		}
+		if (res.status === 204) return null;
+		const ct = res.headers.get("content-type") || "";
+		return ct.includes("application/json") ? res.json() : res.text();
+	}
+
+	return {
+		get: (path, query) => request("GET", path, { query }),
+		post: (path, body, query) => request("POST", path, { body, query }),
+		delete: (path, query) => request("DELETE", path, { query }),
+	};
+}
+
+async function fetchAllAddressTags(http) {
+	const items = [];
+	for (let page = 1; ; page++) {
+		const res = await http.get("/api/v1/monitoring/monitor_tags/", {
+			page,
+			page_size: TAG_PAGE_SIZE,
+			kind: TAG_KIND_ADDRESS,
+		});
+		const got = res.items ?? [];
+		items.push(...got);
+		if (got.length < TAG_PAGE_SIZE) break;
+	}
+	return items;
+}
+
+function normalizeEntitiesByChain(ebc) {
+	const out = new Map();
+	for (const [k, addrs] of Object.entries(ebc ?? {})) {
+		out.set(Number(k), new Set(addrs.map((a) => a.toLowerCase())));
+	}
+	return out;
+}
+
+function discoverChainTag(allTags, chainId) {
+	let best = null;
+	for (const t of allTags) {
+		const ebc = t.entities_by_chain ?? {};
+		const keys = Object.keys(ebc).map(Number);
+		if (keys.length !== 1 || keys[0] !== chainId) continue;
+		const n = ebc[String(chainId)].length;
+		if (!best || n > best.n) best = { tag: t, n };
+	}
+	return best?.tag ?? null;
+}
+
+function readDesiredVaults(chainId) {
+	const products = JSON.parse(
+		fs.readFileSync(`${chainId}/products.json`).toString(),
+	);
+	const out = new Set();
+	for (const product of Object.values(products)) {
+		for (const addr of product.vaults ?? []) out.add(addr.toLowerCase());
+		for (const addr of product.deprecatedVaults ?? [])
+			out.add(addr.toLowerCase());
+	}
+	return out;
+}
+
+function setDiff(a, b) {
+	const out = new Set();
+	for (const x of a) if (!b.has(x)) out.add(x);
+	return out;
+}
+
+async function applyAdds(http, entry, govVault) {
+	const addrs = [...entry.toAdd];
+	log(`chain ${entry.chainId}: adding ${addrs.length} entities…`);
+	for (let i = 0; i < addrs.length; i += ADD_BATCH_SIZE) {
+		const slice = addrs.slice(i, i + ADD_BATCH_SIZE);
+		const body = slice.map((address) => ({
+			monitor_tags: [
+				{ id: govVault.id, name: govVault.name, kind: TAG_KIND_ADDRESS },
+				{
+					id: entry.chainTag.id,
+					name: entry.chainTag.name,
+					kind: TAG_KIND_ADDRESS,
+				},
+			],
+			monitor_entity: {
+				entity_type: ENTITY_TYPE_CONTRACT,
+				params: {
+					type: ENTITY_PARAM_TYPE,
+					address,
+					chain_id: entry.chainId,
+				},
+			},
+		}));
+		await http.post("/api/v1/monitoring/entities_metadata/batch", body);
+	}
+}
+
+async function applyRemoves(http, entry) {
+	const addrs = [...entry.toRemove];
+	log(`chain ${entry.chainId}: removing ${addrs.length} entities…`);
+	const ids = await resolveEntityIds(http, entry.chainId, addrs);
+	for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
+		const slice = ids.slice(i, i + DELETE_BATCH_SIZE);
+		await http.delete("/api/v1/monitoring/entities_metadata/batch", {
+			ids: slice,
+		});
+	}
+}
+
+async function resolveEntityIds(http, chainId, addresses) {
+	const ids = [];
+	for (let i = 0; i < addresses.length; i += ENTITY_RESOLVE_PAGE_SIZE) {
+		const slice = addresses.slice(i, i + ENTITY_RESOLVE_PAGE_SIZE);
+		let page = 1;
+		for (;;) {
+			const res = await http.get("/api/v1/monitoring/entities_metadata/", {
+				page,
+				page_size: ENTITY_RESOLVE_PAGE_SIZE,
+				chains: [chainId],
+				addresses: slice,
+			});
+			const got = res.items ?? [];
+			for (const it of got) ids.push(it.id);
+			if (got.length < ENTITY_RESOLVE_PAGE_SIZE) break;
+			page += 1;
+		}
+	}
+	return ids;
+}
+
+function renderSummary(plan, mode) {
+	const lines = [];
+	lines.push(`# Hexagate sync — ${mode === "apply" ? "applied" : "dry-run"}`);
+	lines.push("");
+	lines.push("| chain | desired | hexagate | +adds | -removes | status |");
+	lines.push("|---|---:|---:|---:|---:|---|");
+	let totalAdd = 0;
+	let totalRemove = 0;
+	for (const e of plan) {
+		const status = e.skipped ? `skipped: ${e.skipped}` : "ok";
+		const add = e.skipped ? "—" : String(e.toAdd.size);
+		const rem = e.skipped ? "—" : String(e.toRemove.size);
+		lines.push(
+			`| ${e.chainId} | ${e.desired.size} | ${e.current.size} | ${add} | ${rem} | ${status} |`,
+		);
+		if (!e.skipped) {
+			totalAdd += e.toAdd.size;
+			totalRemove += e.toRemove.size;
+		}
+	}
+	lines.push(`| **total** |  |  | **${totalAdd}** | **${totalRemove}** |  |`);
+	lines.push("");
+
+	for (const e of plan) {
+		if (e.skipped) continue;
+		if (e.toAdd.size === 0 && e.toRemove.size === 0) continue;
+		lines.push(
+			`<details><summary>chain ${e.chainId}: +${e.toAdd.size} / -${e.toRemove.size}</summary>`,
+		);
+		lines.push("");
+		if (e.toAdd.size > 0) {
+			lines.push("**Add:**");
+			lines.push("");
+			for (const a of [...e.toAdd].sort()) lines.push(`- \`${a}\``);
+			lines.push("");
+		}
+		if (e.toRemove.size > 0) {
+			lines.push("**Remove:**");
+			lines.push("");
+			for (const a of [...e.toRemove].sort()) lines.push(`- \`${a}\``);
+			lines.push("");
+		}
+		lines.push("</details>");
+		lines.push("");
+	}
+
+	const skipped = plan.filter((e) => e.skipped);
+	if (skipped.length > 0) {
+		lines.push("**Skipped chains:**");
+		lines.push("");
+		for (const e of skipped) {
+			lines.push(`- \`${e.chainId}\` — ${e.skipped}`);
+		}
+		lines.push("");
+	}
+
+	return lines.join("\n");
+}
+
+function log(msg) {
+	process.stderr.write(`${msg}\n`);
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"scripts": {
 		"verify": "node verify.js",
+		"sync:hexagate": "node hexagate-sync.js",
 		"fix": "node fix.js && npm run biome:fix",
 		"biome:fix": "biome check --write",
 		"prepare": "husky install",


### PR DESCRIPTION
## Summary

Replaces the perspective-event-driven Hexagate auto-tag rules (deprecating alongside the governed perspective contracts) with an off-chain reconciler that drives `GOV-Vault` tag membership directly from `<chainId>/products.json`.

- New script `hexagate-sync.js` — diffs `vaults ∪ deprecatedVaults` per chain against the current Hexagate `GOV-Vault` membership and applies the difference via `entities_metadata` POST/DELETE batch endpoints.
- New workflow `.github/workflows/sync-hexagate.yml` — dry-run with sticky PR comment on PRs to `master` or `development`; full apply on push to `master`. Concurrency-grouped on `github.ref` so applies queue rather than race.
- New `npm run sync:hexagate` script entry for local invocation.

### Design notes

- **Per-chain tag is auto-discovered**, not hardcoded — the script picks the largest kind=1 tag whose `entities_by_chain` is keyed solely by the labels chain's id. Robust to dashboard renames; gracefully skips chains where no per-chain tag exists yet (= no monitor configured).
- **Only `GOV-Vault` is pinned by name** and the script fails loudly if it disappears.
- **Never creates tags, monitors, or auto-tag rules** — all of those remain dashboard-managed.
- **Removals are entity deletes**, not tag detaches: every removal candidate is by construction a `GOV-Vault` tag holder (it came from that tag's `entities_by_chain`), so the "only delete vault entities" invariant is implicit.
- **`--only <cid>[,<cid>…]`** flag scopes a run to specific chains, supporting incremental rollout.

### Day-1 reconciliation diff (against current Hexagate state)

| chain | cid | desired | hexagate | +adds | -removes | status |
|---|---:|---:|---:|---:|---:|---|
| eth | 1 | 328 | 323 | 63 | 58 | ok |
| bnb | 56 | 53 | 53 | 0 | 0 | ok |
| unichain | 130 | 13 | 17 | 0 | 4 | ok |
| monad | 143 | 58 | 58 | 0 | 0 | ok |
| sonic | 146 | 36 | 0 | 36 | 0 | ok |
| tac | 239 | 22 | 0 | — | — | skipped (no `Tac` per-chain tag) |
| swell | 1923 | 9 | 9 | 0 | 0 | ok |
| base | 8453 | 39 | 46 | 0 | 7 | ok |
| plasma | 9745 | 76 | 66 | 16 | 6 | ok |
| arbitrum | 42161 | 29 | 37 | 7 | 15 | ok |
| avalanche | 43114 | 61 | 59 | 2 | 0 | ok |
| linea | 59144 | 30 | 30 | 2 | 2 | ok |
| bob | 60808 | 3 | 12 | 0 | 9 | ok |
| berachain | 80094 | 42 | 41 | 1 | 0 | ok |
| **total** |  |  |  | **+127** | **−101** |  |

## Test plan

- [x] Add `HEXAGATE_API_KEY` repo secret (read+write).
- [x] Confirm the `Sync Hexagate` job runs on this PR and posts a sticky comment matching the day-1 table above.
- [x] Local round-trip on a low-stakes chain (e.g. `--only 1923`): add a synthetic vault, `--apply`, verify it appears in Hexagate, revert, `--apply` again, verify it's gone.
- [x] Eyeball every per-chain remove list before merging — a remove on day 1 means the address is in Hexagate but not in `products.json`; if any such address should be monitored, fix `products.json` first.
- [x] Apply chain-by-chain with `--only` from a workstation in order of decreasing safety before flipping the master push trigger on for the bulk reconcile (or accept that the first merge to `master` will run the full +127/-101 in CI).
- [ ] Confirm a re-run dry-run reports zeros after the bulk reconcile — that's the "in sync" baseline.

## Out of scope (follow-ups)

- Provisioning `Tac` per-chain tag and `ML-tac-Pausing` monitor in the dashboard so chain 239 can join the sync.
- Cleaning up the 611 empty kind=1 tags accumulated in Hexagate.
- Resolving inconsistent monitor coverage (`ML-monad-Pausing` missing `AlertOnly` sibling; `ML-bob-Pausing`/`ML-swell-Pausing` not configured to filter on `GOV-Vault`).
- Decommissioning the `AT1-*` auto-tag rules and `E65-*-VerifiedGovVault` helper monitors after the new sync has been running cleanly for a while.