### PR TITLE
Add Clearstar ETH Fusion cluster and Earn vault (Base)

### DIFF
--- a/8453/earn-vaults.json
+++ b/8453/earn-vaults.json
@@ -1,5 +1,6 @@
 [
 	"0x8bF41Ad2b816F7c220b22F4BCD63fC2A35Ab4247",
+	"0x6370c6445073b8df18368e3E11Bfecf0cEd13b01",
 	{
 		"address": "0x67f062a12f82c3b42d4CA7a35fb26CbAac28008B",
 		"deprecated": true,

--- a/8453/products.json
+++ b/8453/products.json
@@ -113,5 +113,15 @@
 			"0xEaA709fDb7CCcfbBF5185feBf183F0138cDe5983",
 			"0x0a6Af3A75BB350Fb1a402B70138B9820Cf0CA0Cb"
 		]
+	},
+	"clearstar-eth-fusion": {
+		"name": "Clearstar ETH Fusion",
+		"description": "A market focused on cbAssets. Curated by Clearstar Labs.",
+		"entity": "clearstar",
+		"vaults": [
+			"0x60C61a47804283a514bFCDF163138b7528720D0F",
+			"0xDc4eFB20ce286B421F6361734a2A006a1f24Af8D",
+			"0x91A9ED5d4368499B1fE41f721aB13e64760B3F05"
+		]
 	}
 }


### PR DESCRIPTION
Adds Clearstar ETH Fusion product (cbETH/wETH/USDC isolated market on Base, chainId 8453) to `8453/products.json`, and registers a new Clearstar Euler Earn vault in `8453/earn-vaults.json`.

Products (vaults):
- `0x60C61a47804283a514bFCDF163138b7528720D0F` (cbETH)
- `0xDc4eFB20ce286B421F6361734a2A006a1f24Af8D` (wETH)
- `0x91A9ED5d4368499B1fE41f721aB13e64760B3F05` (USDC)

Earn vault:
- `0x6370c6445073b8df18368e3E11Bfecf0cEd13b01`

Curated by Clearstar Labs. `npm run verify` passes.