### PR TITLE
fix(ci): include all/ scope in S3 sync

### DIFF
--- a/.github/workflows/sync-s3.yml
+++ b/.github/workflows/sync-s3.yml
@@ -32,6 +32,8 @@ jobs:
           for dir in [0-9]*/; do
             [ -d "$dir" ] && cp -r "$dir" _s3_stage/
           done
+          # Copy cross-chain rules directory (e.g. all/assets.json)
+          [ -d all ] && cp -r all _s3_stage/
           # Copy logo directory
           [ -d logo ] && cp -r logo _s3_stage/
 


### PR DESCRIPTION
## Summary

The S3 sync stage glob `[0-9]*/` only matches numeric chain directories. `all/` (and any future non-numeric scope) is silently dropped from the synced bundle, so the labels CDN cannot serve files like `all/assets.json` even though they're committed here.

```
$ curl -s -o /dev/null -w '%{http_code}\n' https://raw.githubusercontent.com/euler-xyz/euler-labels/refs/heads/master/all/assets.json
200
$ curl -s -o /dev/null -w '%{http_code}\n' https://labels.euler.finance/master/all/assets.json
403
```

This adds an explicit `cp -r all _s3_stage/` next to the existing logo copy.

## Test plan
- [ ] Workflow run succeeds on this branch / master
- [ ] After deploy, `https://labels.euler.finance/master/all/assets.json` returns 200 with the expected JSON
- [ ] `euler-lite` server logs no longer warn on `assets.json:all` (cross-chain pattern rules now resolve)