### PR TITLE
ci(hexagate): allow fork PR runs via pull_request_target

### DIFF
--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -103,6 +103,7 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          tmp="$(mktemp)"
           {
             echo "# Hexagate sync — failed"
             echo ""
@@ -115,7 +116,8 @@ jobs:
               echo ""
               echo "</details>"
             fi
-          } > sync-output.md
+          } > "$tmp"
+          mv "$tmp" sync-output.md
 
       - name: Comment PR with diff
         if: always() && github.event_name == 'pull_request_target'

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -31,15 +31,17 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    environment: hexagate-sync
     permissions:
       pull-requests: write
       contents: read
 
     steps:
+      # Always check out the BASE repository — trusted scripts, lockfile, configs.
+      # PR-controlled code (hexagate-sync.js, verify.js, package*.json, etc.) is
+      # NEVER placed where node will execute it with HEXAGATE_API_KEY in scope.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -47,8 +49,31 @@ jobs:
           node-version: "20"
           cache: npm
 
-      - name: Install dependencies
+      - name: Install dependencies (trusted lockfile)
         run: npm ci --ignore-scripts
+
+      # On PR: check out the PR head into an isolated path so we can copy ONLY
+      # the data directories ([0-9]+/, all/, logo/) out of it. JS, package.json,
+      # package-lock.json, biome.json, etc. are deliberately discarded.
+      - name: Stage PR head in isolated path
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: __pr
+          persist-credentials: false
+
+      - name: Overlay PR data directories (passive data only)
+        if: github.event_name == 'pull_request_target'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for src in __pr/[0-9]*/ __pr/all/ __pr/logo/; do
+            name=$(basename "$src")
+            rm -rf "./$name"
+            cp -R "$src" "./$name"
+          done
+          rm -rf __pr
 
       - name: Verify data
         run: node verify.js

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -1,7 +1,7 @@
 name: Sync Hexagate
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - development
@@ -31,12 +31,15 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    environment: hexagate-sync
     permissions:
       pull-requests: write
       contents: read
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -45,7 +48,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Verify data
         run: node verify.js
@@ -54,7 +57,7 @@ jobs:
         id: mode
         run: |
           case "${{ github.event_name }}" in
-            pull_request)     mode="--dry-run" ;;
+            pull_request_target) mode="--dry-run" ;;
             push)             mode="--apply" ;;
             workflow_dispatch) mode="--${{ github.event.inputs.mode }}" ;;
             *)                mode="--dry-run" ;;
@@ -71,7 +74,7 @@ jobs:
           HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
 
       - name: Build failure comment
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request_target'
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -90,14 +93,14 @@ jobs:
           } > sync-output.md
 
       - name: Comment PR with diff
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request_target'
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: hexagate-sync
           path: sync-output.md
 
       - name: Upload sync summary
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request_target'
         uses: actions/upload-artifact@v4
         with:
           name: sync-output


### PR DESCRIPTION
## Summary
Fork PRs (#567 and similar) cannot read repo secrets on `pull_request`, so the Hexagate sync crashed with `HEXAGATE_API_KEY env var is required`. Fix follows the GitHub Security Lab "passive data" pattern from the [pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) post.

## How it works
- `pull_request_target` trigger so the run has access to repo secrets.
- **Checkout BASE first** — `hexagate-sync.js`, `verify.js`, `package.json`, `package-lock.json`, `biome.json`, `fix.js` are always the trusted master versions.
- `npm ci --ignore-scripts` against the trusted lockfile.
- A second `actions/checkout` stages PR head into `__pr/`, then we copy out **only** the data directories: `[0-9]+/`, `all/`, `logo/`. Everything else from the PR (any JS, package files, configs) is discarded before `node` runs.
- `persist-credentials: false` on both checkouts so `GITHUB_TOKEN` does not sit on disk for subsequent steps to read.
- `node verify.js` and `node hexagate-sync.js ${mode}` then run with `HEXAGATE_API_KEY` — but they are the **base-branch scripts**, reading PR-supplied JSON/PNG as passive data only. Neither `eval`s nor `require`s anything from the data dirs.

A fork PR cannot inject executable code into the runner. The API key never sees PR-author scripts.

## Security model vs first attempt
First commit (`cdc451e`) used `pull_request_target` + explicit `ref: pull_request.head.sha` + an environment-gated reviewer approval. This is the exact "INSECURE" example in the GitHub Security Lab post — a malicious fork could rewrite `hexagate-sync.js` to exfiltrate `HEXAGATE_API_KEY`, and the human-review gate is "prone to human error" by GitHub's own assessment. Replaced in `5cc6168` with the data-overlay approach.

## Trade-offs
- PRs that legitimately edit `hexagate-sync.js`, `package.json`, etc. won't get a CI dry-run preview (their changes are stripped before the script runs). Run those via `workflow_dispatch` after merging, or from an internal branch with a manual review.

## Test plan
- [ ] Merge this PR.
- [ ] Re-trigger the Sync Hexagate workflow on PR #567.
- [ ] Verify the dry-run executes, posts the sticky comment with the expected diff for the new Valos labels, and does **not** prompt for environment approval.
- [ ] Confirm an internal-branch PR also runs cleanly.
- [ ] Confirm `push` to master still applies live (with secret).