### PR TITLE
Add asset geo-rules: xStocks, Backed, Dinari + tighten Ondo regex

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -941,6 +941,7 @@
 			"0xD5b4cd50dd2a7dbC74347E572f730fE1eB286a67",
 			"0x61332fE07Ee0faa8a087ba00f43d581871441139",
 			"0xdFa6451EAC51c913003bfeb52418F55376996A64"
-		]
+		],
+		"block": ["CA", "US"]
 	}
 }

--- a/all/assets.json
+++ b/all/assets.json
@@ -8,5 +8,10 @@
 		"nameRegex": "xstock",
 		"block": ["CA", "US"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
+	},
+	{
+		"nameRegex": "uspc",
+		"block": ["CA", "US"],
+		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
 	}
 ]

--- a/all/assets.json
+++ b/all/assets.json
@@ -3,5 +3,10 @@
 		"nameRegex": "ondo",
 		"block": ["CA", "US"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
+	},
+	{
+		"nameRegex": "xstock",
+		"block": ["CA", "US"],
+		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
 	}
 ]

--- a/all/assets.json
+++ b/all/assets.json
@@ -1,6 +1,6 @@
 [
 	{
-		"nameRegex": "ondo",
+		"nameRegex": "^ondo($| )|\\(ondo tokenized\\)",
 		"block": ["CA", "US"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
 	},
@@ -11,6 +11,16 @@
 	},
 	{
 		"nameRegex": "uspc",
+		"block": ["CA", "US"],
+		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
+	},
+	{
+		"nameRegex": "^(wrapped )?backed ",
+		"block": ["CA", "US"],
+		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
+	},
+	{
+		"nameRegex": " - dinari$",
 		"block": ["CA", "US"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
 	}


### PR DESCRIPTION
## Summary

Extends the global asset rules in `all/assets.json` to cover tokenized US securities issued by Backed Finance and Dinari, on top of the original xStocks rule. Also tightens the existing `ondo` regex so it stops false-positiving on unrelated tokens.

Country lists mirror the existing entries: `block: ["CA", "US"]`, `restricted: ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]`.

### Coverage validated against prod token list

Pulled the merged token list (Euler API + Uniswap + DefiLlama + Merkl) from `https://app.euler.finance/api/token-list?chainId=…` for all 14 prod-enabled chains (`1, 56, 130, 143, 146, 239, 1923, 8453, 9745, 42161, 43114, 59144, 60808, 80094`) — 12,814 unique (symbol, name) pairs.

### Rules

| nameRegex | Hits | Notes |
|---|---:|---|
| `^ondo($\| )\|\(ondo tokenized\)` | 269 | Tightened. Drops false positives (CONDO, GONDOLA, MoonDog AI, eONDO-1 vault wrappers) while still catching ONDO governance, OUSG, USDY, USDon, and all 264 `(Ondo Tokenized)` assets |
| `xstock` | 180 | Unchanged from this PR's original scope |
| `uspc` | 3 | Unchanged (merged previously) |
| `^(wrapped )?backed ` | 21 | Backed Finance: bCOIN, bGME, bGOOGL, bMSFT, bMSTR, bNVDA, bTSLA, bNIU, bIB01, bIBTA, bZPR1, bC3M, bCSPX, bCSBGC3, bERNA, bERNX, bHIGH, plus Wrapped variants (wbCOIN/wbMSTR/wbNVDA/wbTSLA). Zero false positives |
| ` - dinari$` | 95 | All Dinari tokens have names ending in `- Dinari`. Zero false positives |

### Out of scope (not added)

- **Securitize-issued institutional funds** (ACRED, HLSCOPE, STAC): KYC enforced at the issuer level.
- **Tokenized treasuries/MMFs** (BUIDL, BENJI, mTBILL, USTB, TBILL, EUTBL/UKTBL/USTBL, tfBILL, thBILL, JTRSY, JAAA, ACRDX, VBILL, WTGXX, etc.): issuer-level KYC + accredited-investor gates, no common name pattern. Can be listed by `symbols` later if we want a second line of defense.

## Test plan
- [ ] `node verify.js` returns `OK` (verified locally)
- [ ] Spot-check on staging: confirm a `bTSLA` / `*.d` / `*on` asset shows geo-block UI in CA/US and the soft-restricted notice in EU/GB
- [ ] Spot-check on staging: confirm `CONDO` / `GONDOLA` / `MoonDog AI` (and `eONDO-1` vaults) are no longer geo-gated