### PR TITLE
fix: harden workflow security

### DIFF
--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -3,18 +3,22 @@ name: Fix Ethereum Addresses and Formatting
 on:
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+
 jobs:
-  fix:
+  generate:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -25,8 +29,43 @@ jobs:
       - name: Fix addresses and formatting
         run: npm run fix
 
+      - name: Upload fixed label files
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fixed-labels
+          include-hidden-files: false
+          if-no-files-found: error
+          path: |
+            [0-9]*/entities.json
+            [0-9]*/points.json
+            [0-9]*/products.json
+            [0-9]*/assets.json
+            [0-9]*/earn-vaults.json
+            all/assets.json
+            biome.json
+            package.json
+            package-lock.json
+
+  create-pr:
+    runs-on: ubuntu-latest
+    needs: generate
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Download fixed label files
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: fixed-labels
+          path: .
+
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: 'fix: normalize ethereum addresses and fix biome formatting'
           title: 'fix: normalize ethereum addresses and fix biome formatting'

--- a/.github/workflows/sync-hexagate.yml
+++ b/.github/workflows/sync-hexagate.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - master
+      - development
   workflow_dispatch:
     inputs:
       mode:
@@ -28,8 +29,12 @@ concurrency:
   group: hexagate-sync-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
-  sync:
+  preview:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -39,12 +44,12 @@ jobs:
       # Always check out the BASE repository — trusted scripts, lockfile, configs.
       # PR-controlled code (hexagate-sync.js, verify.js, package*.json, etc.) is
       # NEVER placed where node will execute it with HEXAGATE_API_KEY in scope.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm
@@ -56,20 +61,26 @@ jobs:
       # the data directories ([0-9]+/, all/, logo/) out of it. JS, package.json,
       # package-lock.json, biome.json, etc. are deliberately discarded.
       - name: Stage PR head in isolated path
-        if: github.event_name == 'pull_request_target'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: __pr
           persist-credentials: false
 
       - name: Overlay PR data directories (passive data only)
-        if: github.event_name == 'pull_request_target'
         run: |
           set -euo pipefail
           shopt -s nullglob
           for src in __pr/[0-9]*/ __pr/all/ __pr/logo/; do
             name=$(basename "$src")
+            if [ -L "${src%/}" ]; then
+              echo "::error::Symlinked PR data directory is not allowed: $name"
+              exit 1
+            fi
+            if find "$src" -type l -print -quit | grep -q .; then
+              echo "::error::Symlinks are not allowed in PR data directory: $name"
+              exit 1
+            fi
             rm -rf "./$name"
             cp -R "$src" "./$name"
           done
@@ -78,28 +89,13 @@ jobs:
       - name: Verify data
         run: node verify.js
 
-      - name: Resolve sync mode
-        id: mode
-        run: |
-          case "${{ github.event_name }}" in
-            pull_request_target) mode="--dry-run" ;;
-            push)             mode="--apply" ;;
-            workflow_dispatch) mode="--${{ github.event.inputs.mode }}" ;;
-            *)                mode="--dry-run" ;;
-          esac
-          only=""
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.only }}" ]; then
-            only="--only=${{ github.event.inputs.only }}"
-          fi
-          echo "args=${mode} ${only}" >> "$GITHUB_OUTPUT"
-
-      - name: Run Hexagate sync
-        run: node hexagate-sync.js ${{ steps.mode.outputs.args }} > sync-output.md
+      - name: Run Hexagate dry-run
+        run: node hexagate-sync.js --dry-run > sync-output.md
         env:
           HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
 
       - name: Build failure comment
-        if: failure() && github.event_name == 'pull_request_target'
+        if: failure()
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
@@ -120,15 +116,96 @@ jobs:
           mv "$tmp" sync-output.md
 
       - name: Comment PR with diff
-        if: always() && github.event_name == 'pull_request_target'
-        uses: marocchino/sticky-pull-request-comment@v2
+        if: always()
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: hexagate-sync
           path: sync-output.md
 
+      - name: Append sync summary to job summary
+        if: always()
+        run: |
+          if [ -f sync-output.md ]; then
+            cat sync-output.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  sync:
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    environment: hexagate-sync
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies (trusted lockfile)
+        run: npm ci --ignore-scripts
+
+      - name: Verify data
+        run: node verify.js
+
+      - name: Resolve sync mode
+        id: mode
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_MODE: ${{ github.event.inputs.mode }}
+          ONLY: ${{ github.event.inputs.only }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          case "$EVENT_NAME" in
+            push)
+              mode="--apply"
+              ;;
+            workflow_dispatch)
+              case "$DISPATCH_MODE" in
+                dry-run)
+                  mode="--dry-run"
+                  ;;
+                apply)
+                  case "$REF_NAME" in
+                    master|development) mode="--apply" ;;
+                    *) echo "::error::Apply mode is only allowed from master or development" ; exit 1 ;;
+                  esac
+                  ;;
+                *) echo "::error::Invalid mode: $DISPATCH_MODE" ; exit 1 ;;
+              esac
+              ;;
+            *)
+              mode="--dry-run"
+              ;;
+          esac
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$ONLY" ]; then
+            ONLY="${ONLY//[[:space:]]/}"
+            if ! [[ "$ONLY" =~ ^[0-9]+(,[0-9]+)*$ ]]; then
+              echo "::error::Invalid only value; expected comma-separated numeric chain IDs"
+              exit 1
+            fi
+            echo "only=$ONLY" >> "$GITHUB_OUTPUT"
+          fi
+          echo "mode=${mode}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Hexagate sync
+        run: |
+          set -euo pipefail
+          args=("${{ steps.mode.outputs.mode }}")
+          if [ -n "${{ steps.mode.outputs.only }}" ]; then
+            args+=("--only=${{ steps.mode.outputs.only }}")
+          fi
+          node hexagate-sync.js "${args[@]}" > sync-output.md
+        env:
+          HEXAGATE_API_KEY: ${{ secrets.HEXAGATE_API_KEY }}
+
       - name: Upload sync summary
-        if: github.event_name != 'pull_request_target'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sync-output
           path: sync-output.md

--- a/.github/workflows/sync-s3.yml
+++ b/.github/workflows/sync-s3.yml
@@ -6,15 +6,22 @@ on:
       - master
       - development
 
+permissions:
+  contents: read
+
 jobs:
-  sync:
+  stage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: npm
@@ -27,43 +34,109 @@ jobs:
 
       - name: Stage data for S3
         run: |
+          set -euo pipefail
           mkdir -p _s3_stage
-          # Copy chain directories (numeric names)
-          for dir in [0-9]*/; do
-            [ -d "$dir" ] && cp -r "$dir" _s3_stage/
+
+          for dir in [0-9]*/ all/ logo/; do
+            [ -e "$dir" ] || continue
+            if [ -L "${dir%/}" ]; then
+              echo "::error::Symlinked deploy directory is not allowed: ${dir%/}"
+              exit 1
+            fi
+            if find "$dir" -type l -print -quit | grep -q .; then
+              echo "::error::Symlinks are not allowed in deploy data: ${dir%/}"
+              exit 1
+            fi
           done
-          # Copy cross-chain rules directory (e.g. all/assets.json)
-          [ -d all ] && cp -r all _s3_stage/
-          # Copy logo directory
-          [ -d logo ] && cp -r logo _s3_stage/
+
+          shopt -s nullglob
+          for dir in [0-9]*/; do
+            mkdir -p "_s3_stage/${dir%/}"
+            for file in entities.json products.json points.json assets.json earn-vaults.json; do
+              [ -f "$dir$file" ] && cp "$dir$file" "_s3_stage/${dir%/}/$file"
+            done
+          done
+
+          mkdir -p _s3_stage/all
+          [ -f all/assets.json ] && cp all/assets.json _s3_stage/all/assets.json
+
+          mkdir -p _s3_stage/logo
+          for file in logo/*; do
+            [ -f "$file" ] || continue
+            cp "$file" "_s3_stage/logo/$(basename "$file")"
+          done
+
+      - name: Upload S3 deploy data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: s3-stage
+          include-hidden-files: false
+          if-no-files-found: error
+          path: _s3_stage/
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: stage
+    environment: s3-sync
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download S3 deploy data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: s3-stage
+          path: _s3_stage
+
+      - name: Verify deploy artifact
+        run: |
+          set -euo pipefail
+          if find _s3_stage -type l -print -quit | grep -q .; then
+            echo "::error::Symlinks are not allowed in deploy artifact"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Sync to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete
+        run: aws s3 sync _s3_stage "s3://${AWS_S3_BUCKET}/${DEST_DIR}" --no-follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: _s3_stage
           DEST_DIR: ${{ github.ref_name }}
 
       - name: Invalidate CloudFront cache
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/${{ github.ref_name }}/*"
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths "$CLOUDFRONT_PATH"
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+          CLOUDFRONT_PATH: /${{ github.ref_name }}/*
 
+  notify:
+    runs-on: ubuntu-latest
+    needs:
+      - stage
+      - deploy
+    if: always() && (needs.stage.result == 'failure' || needs.deploy.result == 'failure')
+    permissions:
+      contents: read
+
+    steps:
       - name: Notify Slack on failure
-        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          STAGE_RESULT: ${{ needs.stage.result }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
         run: |
+          set -euo pipefail
           msg="❌ Sync to S3 failed for ${{ github.ref_name }} in ${{ github.repository }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          msg="$msg Stage: $STAGE_RESULT. Deploy: $DEPLOY_RESULT."
           payload=$(jq -n --arg text "$msg" '{text: $text}')
           curl -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,16 +6,21 @@ on:
       - master
       - development
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary
- Harden GitHub Actions workflows around credentials, artifacts, and deploy side effects.
- Keep PR Hexagate previews automatic while gating real Hexagate syncs and S3 deploys behind protected environments.
- Replace static AWS access keys with GitHub OIDC role assumption for S3/CloudFront operations.

## Changes
- Pin all workflow actions to full commit SHAs and add restrictive default permissions.
- Split automated fix, Hexagate, and S3 workflows so dependency install and untrusted data processing do not run beside write/deploy credentials.
- Add symlink rejection and explicit deploy staging before S3 sync; use --no-follow-symlinks.
- Allow Hexagate apply on both master and development, and block manual apply from other refs.

## DevOps rollout notes
- Create protected GitHub environments named s3-sync and hexagate-sync.
- Move HEXAGATE_API_KEY into the hexagate-sync environment.
- Add AWS_ROLE_TO_ASSUME and AWS_REGION to the s3-sync environment; keep AWS_S3_BUCKET and CLOUDFRONT_DISTRIBUTION_ID available there as well.
- Configure the AWS IAM role trust policy for GitHub OIDC from euler-xyz/euler-labels, restricted to the intended protected refs/environments.
- After environments are configured, run a manual dry-run Hexagate dispatch and confirm S3 deploy succeeds on development before relying on master.

## Test plan
- [x] actionlint .github/workflows/*.yml
- [x] npm run verify && npm run biome
- [x] git diff --check
- [x] Workflow security scan for mutable actions, static AWS keys, persisted checkout credentials, and --follow-symlinks