### PR TITLE
fix(1): remove KPK USDC Prime RWA Earn vault from kpk-securitize product

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -955,17 +955,12 @@
 		"entity": ["kpk", "securitize"],
 		"url": "https://kpk.io/vaults",
 		"vaults": [
-			"0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245",
 			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D",
 			"0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7",
 			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA",
 			"0x8b2d7534Ffcf6c2a9226f439CDaC26c6666E97a9"
 		],
 		"vaultOverrides": {
-			"0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245": {
-				"name": "KPK USDC Prime RWA",
-				"description": "USDC lending vault for KPK-curated RWA markets, with a focus on the Securitize ecosystem. Lenders earn yield from borrowers using tokenised RWA collateral."
-			},
 			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D": {
 				"name": "VBILL Collateral Vault",
 				"description": "Securitize-issued collateral vault for VBILL, a tokenised US Treasury fund. Holders deposit VBILL to mint shares that can be posted as collateral in the VBILL/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users."


### PR DESCRIPTION
## Summary

Removes the KPK USDC Prime RWA Earn vault (\`0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245\`) from the \`kpk-securitize\` product's \`vaults\` array. Keeps the entry in \`1/earn-vaults.json\` as before.

## Context

After PR #615 went live, the Earn vault rendered with several UI issues on app.euler.finance:

- Clicking the Earn vault from the Explore page routes to \`/lend/<addr>\` instead of \`/earn/<addr>\`.
- On that page, both **Risk manager** and **Vault type** show as **Unknown**.
- The Earn vault does not appear in the \`/earn\` list at all.

No other product on \`master\` lists an Earn aggregator inside its \`vaults\` array. The dual-listing (product + earn-vaults.json) appears to confuse the UI's vault-type detection and routing. Removing the Earn vault from the product, while keeping it in \`earn-vaults.json\`, mirrors the pattern used by Sentora and other curators.

The Earn vault remains discoverable via the \`/earn\` page once this fix lands; the Explore-page product \`KPK x Securitize RWA Markets\` now contains only the four market-related vaults (two Securitize collateral wrappers + two USDC lend vaults).

## Verification

- \`npm run verify\` -> OK
- \`npm run biome\` -> no issues