### PR TITLE
Update KPK ETH Yield Term description

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -984,7 +984,7 @@
 	},
 	"kpk-eth-yield-term": {
 		"name": "KPK ETH Yield Term",
-		"description": "Fixed-rate WETH borrowing markets for LST/LRT looping, with borrow rates set monthly from a benchmark ETH staking rate. Curated by KPK.",
+		"description": "Fixed-rate WETH borrowing markets designed for LST/LRT-backed strategies, with borrow rates set monthly from a benchmark ETH staking rate. Curated by KPK.",
 		"entity": ["kpk"],
 		"url": "https://kpk.io/vaults",
 		"vaults": [


### PR DESCRIPTION
## Summary
- Updated the KPK ETH Yield Term product description to describe LST/LRT-backed strategies instead of looping.

## Testing
- Ran `jq empty 1/products.json` to validate JSON syntax.
- Verified the commit is GPG-signed with the configured `thelema <n3tworkspirits@gmail.com>` key.