### PR TITLE
chore: replace product 'keyring' boolean with 'tags' array

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -500,7 +500,7 @@
 			"0x67695A8e976E25D5939aD31297DFCFfC8d050eA0",
 			"0x54Fcb10F9506cf8d16D75346e398539F029240Bd"
 		],
-		"keyring": true
+		"tags": ["keyring"]
 	},
 	"frontier-upshift": {
 		"name": "Frontier Upshift",

--- a/43114/products.json
+++ b/43114/products.json
@@ -89,7 +89,7 @@
 		],
 		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Elixir announcement](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
 		"notExplorable": true,
-		"keyring": true
+		"tags": ["keyring"]
 	},
 	"reservoir-labs-avalanche": {
 		"name": "Reservoir Labs Cluster",

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Each entry in this object corresponds to a lending product, which is primarily a
 * `portfolioNotice`: An optional string displayed as a notice in the user's portfolio view.
 * `notExplorable`: An optional boolean. If true, hides the product from discovery UI.
 * `isGovernanceLimited`: An optional boolean flag for governance-limited products.
-* `keyring`: An optional boolean flag for keyring-type products.
+* `tags`: An optional array of string tags that classify the product. Recognised values include `keyring` (vaults gated by Keyring identity verification) and `access control` (vaults gated by an access-control allowlist hook). Consumers may use tags to render badges and explanatory copy.
 * `block`: An optional array of country code strings where the product is blocked.
 * `recentlyAddedVaults`: An optional array of vault addresses to mark as recently added (sorted to the top of discovery tables). Each must also be in `vaults`.
-* `vaultOverrides`: An optional object of per-vault configuration overrides, keyed by vault address. Each override can contain: `name` (string), `description` (string), `portfolioNotice` (string), `deprecationReason` (string), `block` (string[]), `restricted` (string[]), `notExplorableLend` (boolean), `notExplorableBorrow` (boolean), `keyring` (boolean).
+* `vaultOverrides`: An optional object of per-vault configuration overrides, keyed by vault address. Each override can contain: `name` (string), `description` (string), `portfolioNotice` (string), `deprecationReason` (string), `block` (string[]), `restricted` (string[]), `notExplorableLend` (boolean), `notExplorableBorrow` (boolean), `tags` (string[]).
 
 ### `assets.json`
 

--- a/verify.js
+++ b/verify.js
@@ -32,7 +32,7 @@ const VALID_VAULT_OVERRIDE_KEYS = new Set([
 	"restricted",
 	"notExplorableLend",
 	"notExplorableBorrow",
-	"keyring",
+	"tags",
 ]);
 
 const VALID_ASSET_MATCH_KEYS = new Set([
@@ -172,9 +172,13 @@ function validateChain(chainId) {
 				);
 		}
 
-		if (product.keyring !== undefined) {
-			if (typeof product.keyring !== "boolean")
-				throw Error(`products: keyring must be a boolean: ${productId}`);
+		if (product.tags !== undefined) {
+			if (!Array.isArray(product.tags))
+				throw Error(`products: tags must be an array: ${productId}`);
+			for (const tag of product.tags) {
+				if (typeof tag !== "string")
+					throw Error(`products: tags entries must be strings: ${productId}`);
+			}
 		}
 
 		if (product.block !== undefined) {
@@ -259,13 +263,18 @@ function validateChain(chainId) {
 					throw Error(
 						`products: vaultOverrides notExplorableBorrow must be a boolean for ${addr}: ${productId}`,
 					);
-				if (
-					override.keyring !== undefined &&
-					typeof override.keyring !== "boolean"
-				)
-					throw Error(
-						`products: vaultOverrides keyring must be a boolean for ${addr}: ${productId}`,
-					);
+				if (override.tags !== undefined) {
+					if (!Array.isArray(override.tags))
+						throw Error(
+							`products: vaultOverrides tags must be an array for ${addr}: ${productId}`,
+						);
+					for (const tag of override.tags) {
+						if (typeof tag !== "string")
+							throw Error(
+								`products: vaultOverrides tags entries must be strings for ${addr}: ${productId}`,
+							);
+					}
+				}
 				if (override.block !== undefined) {
 					if (!Array.isArray(override.block))
 						throw Error(


### PR DESCRIPTION
## Summary
Introduces a freeform `tags: string[]` field on products and vault overrides, replacing the single-purpose `keyring` boolean. This lets us classify vaults by multiple, extensible categories (e.g. identity-verification vs. access-control gating) instead of adding a new boolean per hook type.

Recognised tag values today:
- `keyring` — vaults gated by Keyring identity verification
- `access control` — vaults gated by an access-control allowlist hook

## Changes
- **`verify.js`** — `tags` replaces `keyring` in the product-level and `vaultOverrides` validation (must be an array of strings).
- **`README.md`** — schema docs updated (product `tags` bullet + `vaultOverrides` key list).
- **`1/products.json`**, **`43114/products.json`** — the two keyring products migrated from `"keyring": true` to `"tags": ["keyring"]`.

## Deploy ordering
⚠️ Consuming clients are being switched to read `tags` instead of the `keyring` boolean (euler-lite). This labels change should propagate to the served data **before** the euler-lite reader is deployed, otherwise keyring vaults temporarily lose their "Private" classification.

## Verification
- `node verify.js` passes.