### PR TITLE
labels: hide kpk-eth-yield-term term borrows from lend, tag product as access control

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -994,12 +994,15 @@
 		"vaultOverrides": {
 			"0xf55B46C10138782aDE3275D81e44B8464100eAfF": {
 				"name": "KPK wstETH Term Borrow",
-				"description": "Fixed-rate WETH borrowing against wstETH collateral, on a calendar-aligned monthly term. Supply is routed through the KPK ETH Yield Term Earn vault."
+				"description": "Fixed-rate WETH borrowing against wstETH collateral, on a calendar-aligned monthly term. Supply is routed through the KPK ETH Yield Term Earn vault.",
+				"notExplorableLend": true
 			},
 			"0xB5fa20eb3c1A146E1090F24CF3c7D60263Dafa71": {
 				"name": "KPK tETH Term Borrow",
-				"description": "Fixed-rate WETH borrowing against tETH collateral, on a calendar-aligned monthly term. Supply is routed through the KPK ETH Yield Term Earn vault."
+				"description": "Fixed-rate WETH borrowing against tETH collateral, on a calendar-aligned monthly term. Supply is routed through the KPK ETH Yield Term Earn vault.",
+				"notExplorableLend": true
 			}
-		}
+		},
+		"tags": ["access control"]
 	}
 }


### PR DESCRIPTION
## Summary
For the **kpk-eth-yield-term** product (chain 1):

1. **`vaultOverrides.notExplorableLend = true`** on both KPK term-borrow vaults (`0xf55B…`, `0xB5fa…`). Supply for this product is routed through the KPK ETH Yield Term Earn vault, so the term-borrow vaults should not surface as lendable destinations in discovery.
2. **Product-level `tags: ["access control"]`** — the underlying vaults gate operations through a `HookTargetAccessControl` allowlist. Tagging surfaces the new "Access control" chip and explanatory copy in euler-lite (euler-xyz/euler-lite#507).

> **Stacked on #623** (base = `chore/labels-tags-field`). The product-level `tags` field is added by that PR; GitHub will retarget this to `development` once #623 merges.

## Verification
- `node verify.js` passes.

## Related
- euler-xyz/euler-lite#506 — reader for `tags` on master
- euler-xyz/euler-lite#507 — access-control chip on master