### PR TITLE
chore: group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,37 @@
 version: 2
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+    open-pull-requests-limit: 3
     cooldown:
       default-days: 7
+    allow:
+      - dependency-type: "direct"
+    groups:
+      all-updates:
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"
+    ignore:
+      - dependency-name: "@biomejs/biome"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+      day: "monday"
+    open-pull-requests-limit: 3
     cooldown:
       default-days: 7
+    groups:
+      all-actions:
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"


### PR DESCRIPTION
## Summary
- Adopts an euler-lite-style dependabot config: direct deps only, grouped PRs per ecosystem.
- Groups npm updates into one PR per week (Monday) so the 4 direct deps don't spawn 4 PRs.
- Groups github-actions updates the same way — this repo uses 7 actions across 4 workflows, so previously each action bump opened its own PR.
- Ignores `@biomejs/biome` major bumps (v1→v2 has config/rule churn worth opting into deliberately).
- Drops `open-pull-requests-limit` from 5 to 3 per ecosystem.

## Why
8 dependabot PRs are currently open against a repo with only 4 direct npm deps. The flood comes from no grouping, not from a large dep tree. The existing 8 PRs will be closed; the next scheduled run will reopen them as 2 grouped PRs (one npm, one actions) that are easier to triage together.

## Test plan
- [ ] Confirm `dependabot.yml` is valid (GitHub validates on push).
- [ ] After merge, wait for next Monday's dependabot run and verify it produces grouped PRs.