### PR TITLE
labels: add description for KPK ETH Yield Term earn vault

### DIFF
--- a/1/earn-vaults.json
+++ b/1/earn-vaults.json
@@ -9,7 +9,10 @@
 	"0xB4a2fC3adAF3BfA8FCBA2A6FDAA200De106B8825",
 	"0xBc79C4DA0452152D2C329ADE328C79705a964CEE",
 	"0x2B47c128b35DDDcB66Ce2FA5B33c95314a7de245",
-	"0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48",
+	{
+		"address": "0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48",
+		"description": "Earn yield on WETH through KPK-curated fixed-rate ETH term markets, with borrow rates set monthly from a benchmark ETH staking rate, plus a complementary variable-rate allocation for withdrawal liquidity."
+	},
 	{
 		"address": "0x49C5733d71511A78a3E12925ea832f49031c97e9",
 		"deprecated": true,


### PR DESCRIPTION
## Summary

- Add a `description` to the earn-vaults entry for `0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48` (KPK ETH Yield Term, mainnet) so the strategy summary renders on the vault's page in the dApp.

Description text:

> Earn yield on WETH through KPK-curated fixed-rate ETH term markets, with borrow rates set monthly from a benchmark ETH staking rate, plus a complementary variable-rate allocation for withdrawal liquidity.

## Test plan

- [x] `node verify.js` passes
- [ ] Description shows up on the vault page in the dApp after labels reload