### PR TITLE
feat(1): add KPK ETH Yield Term Curator Safe to kpk entity

### DIFF
--- a/1/entities.json
+++ b/1/entities.json
@@ -324,6 +324,7 @@
 		"url": "https://kpk.io/",
 		"addresses": {
 			"0x1572063377a9a4f8065BD7bA0D7fa135cd13051F": "KPK Euler RWA Curation Safe",
+			"0x715f757146846E6D63929bd2c1b334b18B8A1841": "KPK Euler ETH Yield Term Curator Safe",
 			"0x354C92aF243d53A24feb3dFF20372Af7b7c47478": "KPK Security Council Safe"
 		},
 		"social": {


### PR DESCRIPTION
## Summary

Follow-up to [#621](https://github.com/euler-xyz/euler-labels/pull/621). Registers the on-chain governor of the KPK ETH Yield Term stack under the `kpk` entity, so the UI links its markets / oracle router to KPK.

### Change

Adds one address to `1/entities.json` → `kpk.addresses`:

| Address | Label |
|---|---|
| `0x715f757146846E6D63929bd2c1b334b18B8A1841` | KPK Euler ETH Yield Term Curator Safe |

### Why

This Safe is the on-chain governor of:
- The kpk-curated EulerRouter (`0x48Bc0255995Ff585b52eb0F56fc7540cB9b7da5c`)
- The two cyclical borrowable vaults: `eWETH-47` (tETH) and `eWETH-48` (wstETH)
- The Earn vault's `curator()` role (the Earn vault `owner()` is the Security Council, already registered)

It's a 2-of-N Safe distinct from the existing KPK RWA Curation Safe — the two-tier governance (operational Curator Safe + ultimate-admin Security Council) is intentional and mirrors the kpk-securitize stack.

Per Kasper's note in TG ('you can transfer the governance to the address specified in labels'): no on-chain transfer is needed; the issue was that this address wasn't registered in labels. This PR closes that gap.

## Verification

- `npm run verify` -> OK
- `npm run biome` -> no fixes
- On-chain checks:
  - `EulerRouter.governor()` = `0x715f757...` ✓
  - `eWETH-47` / `eWETH-48` governor = `0x715f757...` ✓ (set during deploy)
  - Earn vault `curator()` = `0x715f757...` ✓
  - Earn vault `owner()` = `0x354C92aF...` (Security Council, already in labels) ✓