### PR TITLE
Add Clearstar sUSN isolated market on Base

### DIFF
--- a/8453/products.json
+++ b/8453/products.json
@@ -123,5 +123,14 @@
 			"0xDc4eFB20ce286B421F6361734a2A006a1f24Af8D",
 			"0x91A9ED5d4368499B1fE41f721aB13e64760B3F05"
 		]
+	},
+	"clearstar-susn": {
+		"name": "Clearstar sUSN",
+		"description": "An isolated market for Noon sUSN collateral, configured by Clearstar Labs.",
+		"entity": "clearstar",
+		"vaults": [
+			"0xa6Ad67c0C6c2275B616Fcc81C55DDd76195fCF86",
+			"0x07954BEB7e137101A7cbb3e47864C684aEC50524"
+		]
 	}
 }

--- a/8453/products.json
+++ b/8453/products.json
@@ -125,7 +125,7 @@
 		]
 	},
 	"clearstar-susn": {
-		"name": "Clearstar sUSN",
+		"name": "Clearstar Noon",
 		"description": "An isolated market for Noon sUSN collateral, configured by Clearstar Labs.",
 		"entity": "clearstar",
 		"vaults": [

--- a/8453/products.json
+++ b/8453/products.json
@@ -124,7 +124,7 @@
 			"0x91A9ED5d4368499B1fE41f721aB13e64760B3F05"
 		]
 	},
-	"clearstar-susn": {
+	"clearstar-noon": {
 		"name": "Clearstar Noon",
 		"description": "An isolated market for Noon sUSN collateral, configured by Clearstar Labs.",
 		"entity": "clearstar",


### PR DESCRIPTION
New isolated cluster on Base curated by Clearstar Labs, with Noon sUSN as collateral and a new USDC EVK vault for the loan asset.

| Vault | Address |
| --- | --- |
| sUSN (collateral) | `0xa6Ad67c0C6c2275B616Fcc81C55DDd76195fCF86` |
| USDC (loan) | `0x07954BEB7e137101A7cbb3e47864C684aEC50524` |

Adds the `clearstar-susn` cluster to `8453/products.json`. The `clearstar` entity already exists on Base, so no entity changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)