### PR TITLE
Add Clearstar Fusion WETH/USDC vaults on Base, rename Clearstar product labels

### DIFF
--- a/8453/products.json
+++ b/8453/products.json
@@ -128,8 +128,8 @@
 			"0x0a6Af3A75BB350Fb1a402B70138B9820Cf0CA0Cb"
 		]
 	},
-	"clearstar-eth-fusion": {
-		"name": "Clearstar ETH Fusion",
+	"clearstar-fusion": {
+		"name": "Clearstar Fusion",
 		"description": "A market for cbAssets, configured by Clearstar Labs.",
 		"entity": "clearstar",
 		"vaults": [
@@ -139,7 +139,9 @@
 			"0x6d6021ff46b0d4B800c210Aab3aD10B9E3E53113",
 			"0x82d49919d3Ea4323cd96f9C6E41d9386F36439B2",
 			"0x779225f3d7b6feD3ae3B140815fD338BA974E2C6",
-			"0xB45e4F1003d11a563Bc4f7486edFaFd7dfaa8B4a"
+			"0xB45e4F1003d11a563Bc4f7486edFaFd7dfaa8B4a",
+			"0x3A48aaaa90CF3938290f12F6A1E58C1aeb54699D",
+			"0x8A5FA36779693584E0e52246f05C5b0bF55Df1b1"
 		]
 	},
 	"clearstar-noon": {
@@ -151,8 +153,8 @@
 			"0x07954BEB7e137101A7cbb3e47864C684aEC50524"
 		]
 	},
-	"clearstar-re-isolated": {
-		"name": "Clearstar Re Isolated Cluster",
+	"clearstar-re": {
+		"name": "Clearstar Re",
 		"description": "An isolated market for Re Protocol reUSD collateral, configured by Clearstar Labs.",
 		"entity": "clearstar",
 		"vaults": [

--- a/8453/products.json
+++ b/8453/products.json
@@ -139,9 +139,18 @@
 			"0x6d6021ff46b0d4B800c210Aab3aD10B9E3E53113",
 			"0x82d49919d3Ea4323cd96f9C6E41d9386F36439B2",
 			"0x779225f3d7b6feD3ae3B140815fD338BA974E2C6",
-			"0xB45e4F1003d11a563Bc4f7486edFaFd7dfaa8B4a",
+			"0xB45e4F1003d11a563Bc4f7486edFaFd7dfaa8B4a"
+		]
+	},
+	"clearstar-prime": {
+		"name": "Clearstar Prime",
+		"description": "A Prime market cluster configured by Clearstar Labs.",
+		"entity": "clearstar",
+		"vaults": [
 			"0x3A48aaaa90CF3938290f12F6A1E58C1aeb54699D",
-			"0x8A5FA36779693584E0e52246f05C5b0bF55Df1b1"
+			"0x8A5FA36779693584E0e52246f05C5b0bF55Df1b1",
+			"0x60C61a47804283a514bFCDF163138b7528720D0F",
+			"0x6d6021ff46b0d4B800c210Aab3aD10B9E3E53113"
 		]
 	},
 	"clearstar-noon": {


### PR DESCRIPTION
Adds the two newly deployed Clearstar vaults on Base to the existing Clearstar Fusion product:

- WETH vault: `0x3A48aaaa90CF3938290f12F6A1E58C1aeb54699D`
- USDC vault: `0x8A5FA36779693584E0e52246f05C5b0bF55Df1b1`

Both vaults use the existing Fusion cbETH/cbBTC vaults as collateral, so they belong in the same product on the front-end.

Also renames two Clearstar product labels:

- `clearstar-eth-fusion` -> `clearstar-fusion` (name: "Clearstar Fusion")
- `clearstar-re-isolated` -> `clearstar-re` (name: "Clearstar Re")

`node verify.js` passes.