### PR TITLE
feat: add RLP redemption portfolio notice on arbitrum vaults

### DIFF
--- a/42161/earn-vaults.json
+++ b/42161/earn-vaults.json
@@ -4,6 +4,6 @@
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the Resolv security incident.",
 		"notExplorable": true,
-		"tags": ["RLP redemption ToU"]
+		"portfolioNotice": "(i) In winddown of Euler DAO managed markets the Euler Foundation observed the deficiency in an Euler managed vault.\n(ii) The Euler Foundation determined the most expedient response in this circumstance was to inject value to replace the defective collateral.\n(iii) This is not an admission of liability by the Euler Foundation and does not establish any precedent for any future circumstances relating to the Euler platform, protocol or token or any vault regardless of curator."
 	}
 ]

--- a/42161/earn-vaults.json
+++ b/42161/earn-vaults.json
@@ -3,6 +3,7 @@
 		"address": "0xe4783824593a50Bfe9dc873204CEc171ebC62dE0",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the Resolv security incident.",
-		"notExplorable": true
+		"notExplorable": true,
+		"tags": ["RLP redemption ToU"]
 	}
 ]

--- a/42161/products.json
+++ b/42161/products.json
@@ -45,7 +45,11 @@
 		],
 		"deprecationReason": "Deprecated due to exposure to the Resolv security incident.",
 		"notExplorable": true,
-		"tags": ["RLP redemption ToU"]
+		"vaultOverrides": {
+			"0x05d28A86E057364F6ad1a88944297E58Fc6160b3": {
+				"portfolioNotice": "(i) In winddown of Euler DAO managed markets the Euler Foundation observed the deficiency in an Euler managed vault.\n(ii) The Euler Foundation determined the most expedient response in this circumstance was to inject value to replace the defective collateral.\n(iii) This is not an admission of liability by the Euler Foundation and does not establish any precedent for any future circumstances relating to the Euler platform, protocol or token or any vault regardless of curator."
+			}
+		}
 	},
 	"k3-theo": {
 		"name": "K3 Capital Theo Market",

--- a/42161/products.json
+++ b/42161/products.json
@@ -44,7 +44,8 @@
 			"0x46E57D0dE266638C8339689be04B038049Be3812"
 		],
 		"deprecationReason": "Deprecated due to exposure to the Resolv security incident.",
-		"notExplorable": true
+		"notExplorable": true,
+		"tags": ["RLP redemption ToU"]
 	},
 	"k3-theo": {
 		"name": "K3 Capital Theo Market",


### PR DESCRIPTION
## Summary

Adds a `portfolioNotice` disclosure on Arbitrum (chainId 42161) to the two vaults affected by the Resolv security incident:

- Earn vault `0xe4783824593a50Bfe9dc873204CEc171ebC62dE0` — set directly on the entry in `42161/earn-vaults.json`
- Vault `0x05d28A86E057364F6ad1a88944297E58Fc6160b3` under the `euler-arbitrum-yield` product — set via `vaultOverrides` in `42161/products.json`

Both carry the same legal language framed as three statements:

1. In winddown of Euler DAO managed markets Euler observed the deficiency in an Euler managed vault.
2. Euler determined the most expedient response in this circumstance was to inject value to replace the defective collateral.
3. This is not an admission of liability and does not establish any precedent for any future circumstances relating to the Euler platform, protocol or token or any vault regardless of curator.

This replaces the earlier approach on this branch which used a `"RLP redemption ToU"` tag intended to gate an in-app additional-ToU signing flow. The portfolio notice is a portfolio-level disclosure surfaced by the app, with no on-chain signing component.

## Test plan

- [x] `node verify.js` passes
- [ ] After this PR is merged and the labels CDN/S3 refreshes, the euler-lite app surfaces the portfolio notice on the tagged earn vault and on vault `0x05d28A86E057364F6ad1a88944297E58Fc6160b3` under the `euler-arbitrum-yield` product