### PR TITLE
fix: correct Elixir notice markdown

### DIFF
--- a/43114/earn-vaults.json
+++ b/43114/earn-vaults.json
@@ -5,21 +5,21 @@
 		"address": "0x70c329D6F06b33fa6b75E335B35168B1de84217b",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	{
 		"address": "0xEAF77Df5D03306bCA4EE8b58B6821E6acA76309d",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	{
 		"address": "0xE1A62FDcC6666847d5EA752634E45e134B2F824B",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	}
 ]

--- a/43114/products.json
+++ b/43114/products.json
@@ -26,7 +26,7 @@
 			"0x72F92a966f1874f74e1b601BEe7CF57031B53A03",
 			"0x9298D274A31803bb73c2A5E5EcDd101c581C4AfD"
 		],
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	"mev-capital-avalanche": {
@@ -69,7 +69,7 @@
 			"0x902714C7661697c873C76dEC426b63B2593ecc0a",
 			"0xa4284e26Ae6469aeE8eC38Aa9Db96fc62d6315A1"
 		],
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	"keyring-avalanche": {
@@ -87,7 +87,7 @@
 			"0x3050B75382aB718fAD92D83C5f99c7fDA1654529",
 			"0x2cBb39cdC3c0bA22F857A5A8cA54DEE6D7fD04bF"
 		],
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true,
 		"tags": ["keyring"]
 	},

--- a/9745/earn-vaults.json
+++ b/9745/earn-vaults.json
@@ -6,14 +6,14 @@
 		"address": "0xa5EeD1615cd883dD6883ca3a385F525e3bEB4E79",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	{
 		"address": "0xa9C251F8304b1B3Fc2b9e8fcae78D94Eff82Ac66",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	{

--- a/9745/products.json
+++ b/9745/products.json
@@ -246,7 +246,7 @@
 			"0x3799251bD81925cfcCF2992F10Af27A4e62Bf3F7"
 		],
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults can claim approximately 80% position recovery for a limited time. See the [Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.](https://x.com/elixir/status/2033922212986597612?s=20) for details on how to submit your claim.",
+		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true,
 		"tags": ["governance limited"]
 	},


### PR DESCRIPTION
## Summary
- Fix malformed Markdown in Elixir portfolio notices by removing the nested link shape.
- Preserve the intended expired-claim notice text and keep the X post linked from the words "limited time".

## Changes
- Updates affected Plasma and Avalanche product and earn-vault notices.
- Leaves the message wording unchanged apart from the Markdown syntax needed for correct rendering.

## Test plan
- [x] npm run verify
- [x] git diff --check