### PR TITLE
Add AlphaGrowth Monad AUSD PT vaults

### DIFF
--- a/143/entities.json
+++ b/143/entities.json
@@ -16,6 +16,18 @@
 			"github": "euler-xyz"
 		}
 	},
+	"alphagrowth": {
+		"name": "AlphaGrowth",
+		"logo": "alphagrowth.svg",
+		"description": "AlphaGrowth is a third-party curator using Euler infrastructure to configure lending markets and structured DeFi products. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
+		"url": "https://alphagrowth.io/",
+		"addresses": {
+			"0x4f894Bfc9481110278C356adE1473eBe2127Fd3C": "AlphaGrowth governor multisig (Gnosis Safe, 3-of-8)"
+		},
+		"social": {
+			"twitter": "alphagrowth1"
+		}
+	},
 	"clearstar": {
 		"name": "Clearstar",
 		"logo": "clearstar.svg",

--- a/143/entities.json
+++ b/143/entities.json
@@ -22,7 +22,7 @@
 		"description": "AlphaGrowth is a third-party curator using Euler infrastructure to configure lending markets and structured DeFi products. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://alphagrowth.io/",
 		"addresses": {
-			"0x4f894Bfc9481110278C356adE1473eBe2127Fd3C": "AlphaGrowth governor multisig (Gnosis Safe, 3-of-8)"
+			"0x4f894Bfc9481110278C356adE1473eBe2127Fd3C": "AlphaGrowth governor multisig"
 		},
 		"social": {
 			"twitter": "alphagrowth1"

--- a/143/products.json
+++ b/143/products.json
@@ -1,4 +1,34 @@
 {
+	"alphagrowth-ausd-pt": {
+		"name": "AlphaGrowth AUSD PT",
+		"description": "Borrow AUSD against isolated Pendle AUSD and earnAUSD principal-token collateral on Monad. Curated by AlphaGrowth.",
+		"entity": ["alphagrowth"],
+		"url": "https://alphagrowth.io/",
+		"vaults": [
+			"0x248C74aA002A571c340a3d894aAF294884A49bE1",
+			"0xf3E55a17c4c59Cb70EA44973795fA8F3c3BAad72",
+			"0x7cc566d100E81a9708fd23B18F6B92D3249430C9",
+			"0xC4fAbE0B5A280163aB47E3162689A278C81df3f9"
+		],
+		"vaultOverrides": {
+			"0x248C74aA002A571c340a3d894aAF294884A49bE1": {
+				"name": "AlphaGrowth Isolated AUSD/AUSD-PT",
+				"description": "Lend or borrow AUSD against PT-AUSD-8OCT2026 collateral."
+			},
+			"0xf3E55a17c4c59Cb70EA44973795fA8F3c3BAad72": {
+				"name": "AlphaGrowth Isolated AUSD/AUSD-PT",
+				"description": "Isolated Pendle AUSD principal-token collateral vault."
+			},
+			"0x7cc566d100E81a9708fd23B18F6B92D3249430C9": {
+				"name": "AlphaGrowth Isolated AUSD/earnAUSD-PT",
+				"description": "Lend or borrow AUSD against PT-earnAUSD-8OCT2026 collateral."
+			},
+			"0xC4fAbE0B5A280163aB47E3162689A278C81df3f9": {
+				"name": "AlphaGrowth Isolated AUSD/earnAUSD-PT",
+				"description": "Isolated Pendle earnAUSD principal-token collateral vault."
+			}
+		}
+	},
 	"k3-isolated-btc-ausd": {
 		"name": "Isolated WBTC-AUSD",
 		"description": "An isolated market for WBTC and AUSD, configured by K3 Capital.",


### PR DESCRIPTION
Add labels for the new AlphaGrowth AUSD PT product on Monad with 2 isolated markets:
1. AUSD/PT-AUSD-8OCT2026
2. AUSD/PT-earnAUSD-8OCT2026

<img width="1095" height="477" alt="Screenshot 2026-06-20 at 5 35 05 PM" src="https://github.com/user-attachments/assets/7c023cf3-1fe0-48a9-bf9f-a68768fd9f4d" />

<img width="915" height="556" alt="Screenshot 2026-06-20 at 5 35 35 PM" src="https://github.com/user-attachments/assets/263633cd-2bc1-4a22-8d8d-dec4051ae0c5" />
