### PR TITLE
fix: bump ethers dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "euler-labels",
 			"version": "1.0.0",
 			"dependencies": {
-				"ethers": "6.13.5",
+				"ethers": "6.17.0",
 				"image-size": "1.2.1"
 			},
 			"devDependencies": {
@@ -20,9 +20,9 @@
 			}
 		},
 		"node_modules/@adraffy/ens-normalize": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-			"integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+			"integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
 			"license": "MIT"
 		},
 		"node_modules/@biomejs/biome": {
@@ -241,9 +241,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ethers": {
-			"version": "6.13.5",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.5.tgz",
-			"integrity": "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+			"integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
 			"funding": [
 				{
 					"type": "individual",
@@ -256,13 +256,13 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@adraffy/ens-normalize": "1.10.1",
+				"@adraffy/ens-normalize": "1.11.1",
 				"@noble/curves": "1.2.0",
 				"@noble/hashes": "1.3.2",
 				"@types/node": "22.7.5",
 				"aes-js": "4.0.0-beta.5",
 				"tslib": "2.7.0",
-				"ws": "8.17.1"
+				"ws": "8.21.0"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -327,9 +327,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ws": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-			"integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"biome": "biome check"
 	},
 	"dependencies": {
-		"ethers": "6.13.5",
+		"ethers": "6.17.0",
 		"image-size": "1.2.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary
- Bump ethers to 6.17.0
- Refresh the lockfile so ethers resolves ws 8.21.0
- Clear the current ws npm audit advisory reported in PR checks

## Test
- npm ci --ignore-scripts
- npm audit --audit-level high
- node verify.js
- npm run biome
- git diff --check