### PR TITLE
fix: support image-size v2 in verifier

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -1,7 +1,7 @@
 const fs = require("node:fs");
 
 const ethers = require("ethers");
-const imageSize = require("image-size");
+const { imageSize } = require("image-size");
 
 const logos = {};
 
@@ -11,7 +11,7 @@ for (let i = 0; i < fs.readdirSync("logo/").length; i++) {
 }
 
 for (const file of Object.keys(logos)) {
-	const info = imageSize(`logo/${file}`);
+	const info = imageSize(fs.readFileSync(`logo/${file}`));
 
 	if (info.type !== "svg" && info.type !== "png" && info.type !== "jpg") {
 		throw Error(`logo file ${file} is not SVG/PNG/JPG`);


### PR DESCRIPTION
## Summary
- Update verify.js for the image-size 2.x CommonJS API
- Pass logo file buffers to imageSize instead of file paths
- Fixes the base development verifier used by pull_request_target preview jobs

## Test
- npm ci --ignore-scripts
- node verify.js
- npm run biome
- git diff --check

## Note
The pull_request_target preview job runs trusted scripts from the current base branch, so this PR may show the same preview failure until this verifier fix is merged into development.