### PR TITLE
Add new vaults to the AlphaGrowth Base RWA market

### DIFF
--- a/8453/products.json
+++ b/8453/products.json
@@ -96,12 +96,15 @@
 	},
 	"alphagrowth-base-rwa": {
 		"name": "AlphaGrowth Base RWA",
-		"description": "A Base market for reUSD and USDC, configured by AlphaGrowth.",
+		"description": "A Base market for the selected RWA assets, configured by AlphaGrowth.",
 		"entity": ["alphagrowth"],
 		"url": "https://alphagrowth.io/",
 		"vaults": [
 			"0x81744B5B5527852832F2dd3554C191d3B1342108",
-			"0x4C1aeda9B43EfcF1da1d1755b18802aAbe90f61E"
+			"0x4C1aeda9B43EfcF1da1d1755b18802aAbe90f61E",
+			"0xd54d33dA9C326AEE7513cEFdedA5c93a41809caD",
+			"0xD864d46c62685A6062A722AFD7C8c978c410aAaF",
+			"0x2645CBAF62F2f336B0e988375d7e6bCAb66A296C"
 		]
 	},
 	"alphagrowth-base-ai": {

--- a/8453/products.json
+++ b/8453/products.json
@@ -105,6 +105,8 @@
 			"0xd54d33dA9C326AEE7513cEFdedA5c93a41809caD",
 			"0xD864d46c62685A6062A722AFD7C8c978c410aAaF",
 			"0x2645CBAF62F2f336B0e988375d7e6bCAb66A296C"
+		],
+		"block": ["GB", "US"]
 		]
 	},
 	"alphagrowth-base-ai": {

--- a/8453/products.json
+++ b/8453/products.json
@@ -107,7 +107,6 @@
 			"0x2645CBAF62F2f336B0e988375d7e6bCAb66A296C"
 		],
 		"block": ["GB", "US"]
-		]
 	},
 	"alphagrowth-base-ai": {
 		"name": "AlphaGrowth Base AI",


### PR DESCRIPTION
Add 3 new vaults for ST0x RWA assets (wtSPYM, wtMSTR, wtCOIN) to the existing AlphaGrowth Base RWA market: https://app.euler.finance/lend/0x4C1aeda9B43EfcF1da1d1755b18802aAbe90f61E?network=8453

Updated:
1. All 3 vaults have been redeployed to use DIA's official chainlink-style wrappers instead of custom oracle adapters.
2. Borrowing functionality has been disabled for the new vaults to minimize the risk of the [ERC-4626 donation attack](https://docs.euler.finance/security/attack-vectors/donation-attacks).

<img width="973" height="540" alt="Screenshot 2026-07-22 at 11 11 37 AM" src="https://github.com/user-attachments/assets/c0f99d9a-fee9-4606-98b7-641781a648be" />

<img width="1093" height="479" alt="Screenshot 2026-07-22 at 11 12 17 AM" src="https://github.com/user-attachments/assets/1865999a-d403-406f-b181-ecb95e7dc9d3" />
