### PR TITLE
Add ROY-ST-sUSN vault to Clearstar Noon product on Base

### DIFF
--- a/8453/products.json
+++ b/8453/products.json
@@ -148,7 +148,8 @@
 		"entity": "clearstar",
 		"vaults": [
 			"0xa6Ad67c0C6c2275B616Fcc81C55DDd76195fCF86",
-			"0x07954BEB7e137101A7cbb3e47864C684aEC50524"
+			"0x07954BEB7e137101A7cbb3e47864C684aEC50524",
+			"0xb82FfabE9C1a95619ff24E21ccaf05A933c3b206"
 		]
 	},
 	"clearstar-re": {


### PR DESCRIPTION
Adds the Royco senior tranche sUSN collateral vault to the existing `clearstar-noon` product in `8453/products.json`. The vault was deployed after #634 and currently shows as "Unknown" in the dApp.

| Vault | Address |
| --- | --- |
| ROY-ST-sUSN (collateral) | `0xb82FfabE9C1a95619ff24E21ccaf05A933c3b206` |

The vault is an EVK vault (`eROY-ST-sUSN-1`) holding the Royco senior tranche receipt token `0x98d55707B60793AC8cadAB3C456dA156671F138a` (srRoySUSN, "Royco Senior Tranche sUSN"). The on-chain symbol already provides the display name, so no `vaultOverrides` are needed.

`npm run verify` passes.