### PR TITLE
Add Hyperithm mHyperBTC market on Monad

### DIFF
--- a/143/products.json
+++ b/143/products.json
@@ -298,6 +298,15 @@
 			"0x19CE855d819B2a753d4CEcfFff9dCAac721f1FbB"
 		]
 	},
+	"hyperithm-mhyperbtc": {
+		"name": "Hyperithm mHyperBTC",
+		"description": "An isolated market dedicated to mHyperBTC and other BTC correlated assets.",
+		"entity": ["hyperithm"],
+		"vaults": [
+			"0x7d05F99d19bc46215a0a2E2A421174B8F44772B5",
+			"0xa0752257825a6444C48D71796bF657b2AfB1A212"
+		]
+	},
 	"valos-vusd-ausd": {
 		"name": "Valos vUSD/AUSD Market",
 		"description": "Euler market for Valos evUSD and eAUSD.",


### PR DESCRIPTION
## Summary

Adds the new **Hyperithm mHyperBTC** isolated market on Monad (chain 143) to `143/products.json`, following the same format as the existing `hyperithm-ahyperbtc` product.

Vaults:
- `0x7d05F99d19bc46215a0a2E2A421174B8F44772B5` — emHyperBTC-3 (collateral, escrow/supply-only)
- `0xa0752257825a6444C48D71796bF657b2AfB1A212` — ecbBTC-5 (borrowable)

The `hyperithm` entity already exists in `143/entities.json`, so no entity changes are needed.