### PR TITLE
AlphaGrowth Base RWA market: Apply geo restrictions only to the new ST0x vaults

### DIFF
--- a/8453/products.json
+++ b/8453/products.json
@@ -106,7 +106,17 @@
 			"0xD864d46c62685A6062A722AFD7C8c978c410aAaF",
 			"0x2645CBAF62F2f336B0e988375d7e6bCAb66A296C"
 		],
-		"block": ["GB", "US"]
+		"vaultOverrides": {
+			"0xd54d33dA9C326AEE7513cEFdedA5c93a41809caD": {
+				"block": ["GB", "US"]
+			},
+			"0xD864d46c62685A6062A722AFD7C8c978c410aAaF": {
+				"block": ["GB", "US"]
+			},
+			"0x2645CBAF62F2f336B0e988375d7e6bCAb66A296C": {
+				"block": ["GB", "US"]
+			}
+		}
 	},
 	"alphagrowth-base-ai": {
 		"name": "AlphaGrowth Base AI",


### PR DESCRIPTION
Update applied geo restrictions from all vaults of the market to the new wtCOIN, wtMSTR, and wtSPYM vaults only via vault overrides.