### PR TITLE
feat: add Stream claim portfolio notices

### DIFF
--- a/1/earn-vaults.json
+++ b/1/earn-vaults.json
@@ -20,19 +20,22 @@
 		"address": "0x49C5733d71511A78a3E12925ea832f49031c97e9",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"notExplorable": true
+		"notExplorable": true,
+		"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
 	},
 	{
 		"address": "0xd217A07493b6BA272Ff806EE5eaBdFF86C292cc6",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"notExplorable": true
+		"notExplorable": true,
+		"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
 	},
 	{
 		"address": "0xA5cbf5cd429af63EA9989aE1ff4C9d37acFa6767",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"notExplorable": true
+		"notExplorable": true,
+		"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
 	},
 	{
 		"address": "0x018b86A893F57a632F90c4A8308353Ac938adc01",

--- a/1/products.json
+++ b/1/products.json
@@ -688,7 +688,18 @@
 			"0x0f080Bf8Ba818001EcfB2f461708D8484323D0cE"
 		],
 		"deprecationReason": "Deprecated due to exposure to insolvent positions held by Stream. Contact TelosC for information about future redemption.",
-		"notExplorable": true
+		"notExplorable": true,
+		"vaultOverrides": {
+			"0x01864aE3c7d5f507cC4c24cA67B4CABbDdA37EcD": {
+				"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
+			},
+			"0x211711F277f146fC947D7053B41BB71BB5b5FC2C": {
+				"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
+			},
+			"0x038dd0Eb275B7DE3B07884f1Fa106eD6423C45F2": {
+				"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
+			}
+		}
 	},
 	"horizon-clearstar": {
 		"name": "Horizon Clearstar",

--- a/9745/earn-vaults.json
+++ b/9745/earn-vaults.json
@@ -13,7 +13,7 @@
 		"address": "0xa9C251F8304b1B3Fc2b9e8fcae78D94Eff82Ac66",
 		"deprecated": true,
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"portfolioNotice": "Eligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
+		"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment.\n\nEligible users of impacted vaults could have claimed approximately 80% position recovery for a [limited time](https://x.com/elixir/status/2033922212986597612?s=20). The claim period has expired. Please contact Elixir for more information.",
 		"notExplorable": true
 	},
 	{

--- a/9745/products.json
+++ b/9745/products.json
@@ -108,7 +108,12 @@
 			"0x138c289Bb8b855CF271305C8bcf91DC31Ba30194"
 		],
 		"deprecationReason": "Deprecated due to exposure to the insolvent positions held by Stream.",
-		"notExplorable": true
+		"notExplorable": true,
+		"vaultOverrides": {
+			"0x57c582346B7d49A46Af3745A8278917D1c1311b8": {
+				"portfolioNotice": "Stream is collecting and confirming information regarding potential creditors and claimants. If you were exposed through this vault and have not already provided this information, [use Stream's updated form](https://forms.streamsoftrestructuring.com/) promptly and identify Euler/TelosC in your submission. Do not submit again if you already did. Submission does not establish or confirm any claim, entitlement, or right to payment."
+			}
+		}
 	},
 	"edge-capital-core-cluster": {
 		"name": "Edge UltraYield Cluster",


### PR DESCRIPTION
## Summary

- Add a current Stream information-submission notice to the affected TelosC Surge WBTC, USDC, and WETH Earn vaults on Ethereum and tcUSDT0 on Plasma.
- Add the same notice through selective `vaultOverrides` on the four directly affected EVK lending vaults.
- Preserve the existing expired Elixir recovery notice on the Plasma Earn vault as a second paragraph.

## Why

TelosC asked affected users to submit their information individually after updated guidance. Stream subsequently replaced the older DocuSign route with `forms.streamsoftrestructuring.com` and instructed users who already submitted not to submit again.

The notice uses the current Stream destination and retains Stream's disclaimer that submission does not establish or confirm any claim, entitlement, or right to payment.

Context:

- https://x.com/TelosConsilium/status/2085627281435930982
- https://x.com/StreamDefi/status/2077216184974311866
- https://x.com/SiloFinance/status/2085008000138567956

## User impact

Affected holders will see an actionable notice in the portfolio view on both their Earn position and the directly affected EVK position. Discovery and deprecation behavior are unchanged.

## Validation

- `npm run verify`
- `npm run biome -- 1/earn-vaults.json 1/products.json 9745/earn-vaults.json 9745/products.json`
- `git diff --check`
