### PR TITLE
chore: label MPC custody on entity addresses that are EOAs on-chain

### DIFF
--- a/1/entities.json
+++ b/1/entities.json
@@ -351,6 +351,9 @@
 		"logo": "jpeg-trading.svg",
 		"description": "JPEG Trading is a third-party curator using Euler infrastructure to configure isolated lending markets. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://jpeg-trading.com/",
+		"addresses": {
+			"0x3268eaFEECBd1B77E1c0B15F144224E7F725d102": "JPEG Trading Vault & Oracle Router Governor (MPC)"
+		},
 		"social": {
 			"twitter": "JPEGTrading"
 		}

--- a/1/entities.json
+++ b/1/entities.json
@@ -351,9 +351,6 @@
 		"logo": "jpeg-trading.svg",
 		"description": "JPEG Trading is a third-party curator using Euler infrastructure to configure isolated lending markets. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://jpeg-trading.com/",
-		"addresses": {
-			"0x3268eaFEECBd1B77E1c0B15F144224E7F725d102": "JPEG Trading Vault & Oracle Router Governor"
-		},
 		"social": {
 			"twitter": "JPEGTrading"
 		}

--- a/43114/entities.json
+++ b/43114/entities.json
@@ -79,9 +79,6 @@
 		"logo": "turtle.png",
 		"description": "Turtle is a third-party curator using Euler infrastructure to configure vaults connected to liquidity distribution strategies. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://turtle.xyz/",
-		"addresses": {
-			"0x2631b5260715ec9F1211EF0Fb10c702922038B63": "Turtle Multisig"
-		},
 		"social": {
 			"twitter": "turtledotxyz"
 		}

--- a/43114/entities.json
+++ b/43114/entities.json
@@ -79,6 +79,9 @@
 		"logo": "turtle.png",
 		"description": "Turtle is a third-party curator using Euler infrastructure to configure vaults connected to liquidity distribution strategies. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://turtle.xyz/",
+		"addresses": {
+			"0x2631b5260715ec9F1211EF0Fb10c702922038B63": "Turtle MPC wallet"
+		},
 		"social": {
 			"twitter": "turtledotxyz"
 		}


### PR DESCRIPTION
An on-chain sweep of all declared entity addresses found two bare EOAs whose labels did not state their custody. Both are MPC-custodied, so their labels now say so (matching the convention used by every other MPC-custodied entity address):

- **turtle (43114)**: `0x2631b5260715ec9F1211EF0Fb10c702922038B63` — "Turtle Multisig" → "Turtle MPC wallet" (the address has no code on-chain, so the multisig label was misleading).
- **jpeg-trading (1)**: `0x3268eaFEECBd1B77E1c0B15F144224E7F725d102` — "JPEG Trading Vault & Oracle Router Governor" → "JPEG Trading Vault & Oracle Router Governor (MPC)".

`node verify.js` passes.