### PR TITLE
ci: allowlist unfixable image-size advisories in the audit gate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,7 +42,11 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Audit dependencies
-        run: npm audit --audit-level high
+        # image-size <= 2.0.2 (the latest release) carries two unfixable
+        # high-severity DoS advisories in parsers this repo never feeds
+        # (ICNS/JXL/HEIF); allowlist them so the gate stays live for
+        # everything else and self-heals once a patched release ships.
+        run: npx audit-ci@7.1.0 --high --allowlist GHSA-w3rx-r6r6-pgpr GHSA-5p2g-fcmc-qvqq
 
       - name: Run verify.js
         run: node verify.js


### PR DESCRIPTION
The `verify` job fails on every PR: `npm audit --audit-level high` trips on `image-size@2.0.2`, which is the **latest release** — both advisories (GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq) have `first_patched_version: null`, so Dependabot can only raise alerts (repo alerts #3–#6) and never a PR, and no bump can fix the gate.

The advisories are DoS-through-infinite-loop in the ICNS/JXL/HEIF parsers; this repo only feeds `image-size` PNG/SVG/WebP logos in `verify.js`, at CI time. This swaps the audit step to `audit-ci` (pinned 7.1.0) with exactly those two advisories allowlisted — the high-severity gate stays live for every other dependency, and when a patched `image-size` ships, the allowlist entries become inert and can be dropped.