### PR TITLE
refactor: split Securitize collateral vaults into their own product

### DIFF
--- a/1/products.json
+++ b/1/products.json
@@ -963,39 +963,49 @@
 		"url": "https://kpk.io/vaults",
 		"tags": ["suppress high utilisation warning"],
 		"vaults": [
-			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D",
 			"0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7",
-			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA",
 			"0x8b2d7534Ffcf6c2a9226f439CDaC26c6666E97a9",
-			"0x4ab4bEab100d028deCB6835c8f6916031D73793e",
 			"0xd06836F33C9c3c1D372097952C0e60240B1a3fDE"
+		],
+		"vaultOverrides": {
+			"0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7": {
+				"name": "KPK VBILL/USDC Lend",
+				"description": "USDC lending vault for the KPK VBILL market. Borrowers post VBILL, a Securitize-issued tokenised US Treasury fund, as collateral."
+			},
+			"0x8b2d7534Ffcf6c2a9226f439CDaC26c6666E97a9": {
+				"name": "KPK STAC/USDC Lend",
+				"description": "USDC lending vault for the KPK STAC market. Borrowers post STAC, a Securitize-issued tokenised AAA CLO fund, as collateral."
+			},
+			"0xd06836F33C9c3c1D372097952C0e60240B1a3fDE": {
+				"name": "KPK HINC/USDC Lend",
+				"description": "USDC lending vault for the KPK HINC market. Borrowers post HINC, a Securitize-issued tokenised high-yield credit fund, as collateral.",
+				"tags": ["recently added"]
+			}
+		}
+	},
+	"securitize": {
+		"name": "Securitize RWA Collateral",
+		"description": "Issuer-governed collateral vaults for Securitize-issued tokenised RWAs. Holders deposit Securitize fund tokens to mint shares that can be posted as collateral on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users.",
+		"entity": ["securitize"],
+		"logo": "securitize.png",
+		"url": "https://securitize.io/",
+		"vaults": [
+			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D",
+			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA",
+			"0x4ab4bEab100d028deCB6835c8f6916031D73793e"
 		],
 		"vaultOverrides": {
 			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D": {
 				"name": "VBILL Collateral Vault",
 				"description": "Securitize-issued collateral vault for VBILL, a tokenised US Treasury fund. Holders deposit VBILL to mint shares that can be posted as collateral in the VBILL/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users."
 			},
-			"0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7": {
-				"name": "KPK VBILL/USDC Lend",
-				"description": "USDC lending vault for the KPK VBILL market. Borrowers post VBILL, a Securitize-issued tokenised US Treasury fund, as collateral."
-			},
 			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA": {
 				"name": "STAC Collateral Vault",
 				"description": "Securitize-issued collateral vault for STAC, a tokenised AAA CLO fund. Holders deposit STAC to mint shares that can be posted as collateral in the STAC/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users."
 			},
-			"0x8b2d7534Ffcf6c2a9226f439CDaC26c6666E97a9": {
-				"name": "KPK STAC/USDC Lend",
-				"description": "USDC lending vault for the KPK STAC market. Borrowers post STAC, a Securitize-issued tokenised AAA CLO fund, as collateral."
-			},
-
 			"0x4ab4bEab100d028deCB6835c8f6916031D73793e": {
 				"name": "HINC Collateral Vault",
 				"description": "Securitize-issued collateral vault for HINC, a tokenised high-yield credit fund sub-advised by Neuberger Berman. Holders deposit HINC to mint shares that can be posted as collateral in the HINC/USDC market on Euler. Access is limited to eligible, KYC-approved users, enforced by Securitize as transfer agent at the token level.",
-				"tags": ["recently added"]
-			},
-			"0xd06836F33C9c3c1D372097952C0e60240B1a3fDE": {
-				"name": "KPK HINC/USDC Lend",
-				"description": "USDC lending vault for the KPK HINC market. Borrowers post HINC, a Securitize-issued tokenised high-yield credit fund, as collateral.",
 				"tags": ["recently added"]
 			}
 		}

--- a/1/products.json
+++ b/1/products.json
@@ -997,15 +997,21 @@
 		"vaultOverrides": {
 			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D": {
 				"name": "VBILL Collateral Vault",
-				"description": "Securitize-issued collateral vault for VBILL, a tokenised US Treasury fund. Holders deposit VBILL to mint shares that can be posted as collateral in the VBILL/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users."
+				"description": "Securitize-issued collateral vault for VBILL, a tokenised US Treasury fund. Holders deposit VBILL to mint shares that can be posted as collateral in the VBILL/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users.",
+				"notExplorableLend": true,
+				"notExplorableBorrow": true
 			},
 			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA": {
 				"name": "STAC Collateral Vault",
-				"description": "Securitize-issued collateral vault for STAC, a tokenised AAA CLO fund. Holders deposit STAC to mint shares that can be posted as collateral in the STAC/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users."
+				"description": "Securitize-issued collateral vault for STAC, a tokenised AAA CLO fund. Holders deposit STAC to mint shares that can be posted as collateral in the STAC/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users.",
+				"notExplorableLend": true,
+				"notExplorableBorrow": true
 			},
 			"0x4ab4bEab100d028deCB6835c8f6916031D73793e": {
 				"name": "HINC Collateral Vault",
 				"description": "Securitize-issued collateral vault for HINC, a tokenised high-yield credit fund sub-advised by Neuberger Berman. Holders deposit HINC to mint shares that can be posted as collateral in the HINC/USDC market on Euler. Access is limited to eligible, KYC-approved users, enforced by Securitize as transfer agent at the token level.",
+				"notExplorableLend": true,
+				"notExplorableBorrow": true,
 				"tags": ["recently added"]
 			}
 		}

--- a/1/products.json
+++ b/1/products.json
@@ -998,20 +998,17 @@
 			"0xCf4846E0d8A8667c516B844EB72A4d6e7430101D": {
 				"name": "VBILL Collateral Vault",
 				"description": "Securitize-issued collateral vault for VBILL, a tokenised US Treasury fund. Holders deposit VBILL to mint shares that can be posted as collateral in the VBILL/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users.",
-				"notExplorableLend": true,
-				"notExplorableBorrow": true
+				"notExplorableLend": true
 			},
 			"0x1cFC56665c2718454e8dDf975dC37aF0bc68B5aA": {
 				"name": "STAC Collateral Vault",
 				"description": "Securitize-issued collateral vault for STAC, a tokenised AAA CLO fund. Holders deposit STAC to mint shares that can be posted as collateral in the STAC/USDC market on Euler. Governed by Securitize; access is limited to eligible, KYC-approved users.",
-				"notExplorableLend": true,
-				"notExplorableBorrow": true
+				"notExplorableLend": true
 			},
 			"0x4ab4bEab100d028deCB6835c8f6916031D73793e": {
 				"name": "HINC Collateral Vault",
 				"description": "Securitize-issued collateral vault for HINC, a tokenised high-yield credit fund sub-advised by Neuberger Berman. Holders deposit HINC to mint shares that can be posted as collateral in the HINC/USDC market on Euler. Access is limited to eligible, KYC-approved users, enforced by Securitize as transfer agent at the token level.",
 				"notExplorableLend": true,
-				"notExplorableBorrow": true,
 				"tags": ["recently added"]
 			}
 		}


### PR DESCRIPTION
## Summary

Moves the three Securitize-issued collateral wrappers (VBILL, STAC, HINC) out of `kpk-securitize` into a new `securitize` product owned by the `securitize` entity. All vault names, descriptions, and tags move verbatim; the KPK lend vaults stay where they are. The wrappers additionally get `notExplorableLend` so they are not presented as lend markets — deposits into them are KYC-gated wrapping, not lending. `notExplorableBorrow` is deliberately **not** set: the borrow page hides any pair whose collateral carries that flag, and borrowing against the wrappers is exactly the product.

## Why

The wrappers are governed on-chain by Securitize (governorAdmin = the Securitize MPC wallet `0x22F5…528B`), while the KPK lend vaults are governed by the KPK Curation Safe (`0x1572…051F`). Product membership should reflect that split:

- The wrappers are shared infrastructure — any curator's market can accept them as collateral (gated by Securitize's on-chain controller perspective), so they shouldn't appear to belong to KPK's product.
- The V3 data services model one owning entity per product and verify on-chain control of every member vault against that entity; the mixed-governance membership cannot verify there. With this split, both products verify.
- `kpk-securitize` keeps `"entity": ["kpk", "securitize"]`, preserving the Securitize co-branding and the existing governor verification for the lend vaults.

## Consumer impact

- Verification is unchanged for every vault: the union rule (governor ∈ declared entities' addresses) resolves identically before and after — wrappers match Securitize, lend vaults match KPK.
- Names/descriptions resolve from the owning product's `vaultOverrides`, which move with the vaults — display strings are identical.
- Borrow pairs against the wrappers (VBILL/USDC, STAC/USDC, HINC/USDC) remain listed: pair visibility keys off `notExplorableBorrow`, which stays unset.
- Lend listings drop the wrappers via `notExplorableLend`. The wrappers also stop inheriting the product-level `suppress high utilisation warning` tag, which is irrelevant to collateral-only wrappers.
- The new `securitize` product would appear as a market card on Explore; euler-xyz/euler-lite#816 is the companion change that keeps collateral-only products (no explorable side on any member) out of market discovery while their vaults stay resolvable as external collateral and via direct URL.
- Note: apps reading labels from `master` at runtime pick this up on merge — treat the merge as the release, and land the euler-lite companion first if the Explore card matters.

`node verify.js` passes.