### PR TITLE
fix: label K3 Safe on BSC

### DIFF
--- a/56/entities.json
+++ b/56/entities.json
@@ -42,7 +42,8 @@
 		"description": "K3 Capital is a third-party curator using Euler infrastructure to configure vaults across selected DeFi markets. The curator is responsible for asset selection, vault parameter configuration, and management of the vaults it configures.",
 		"url": "https://k3.capital/",
 		"addresses": {
-			"0x5Bb012482Fa43c44a29168C6393657130FDF0506": "K3 Capital Fireblocks Multisig"
+			"0x5Bb012482Fa43c44a29168C6393657130FDF0506": "K3 Capital Fireblocks Multisig",
+			"0x060DB084bF41872861f175d83f3cb1B5566dfEA3": "K3 Fireblocks wallet"
 		},
 		"social": {
 			"twitter": "k3_capital"


### PR DESCRIPTION
## Summary

- adds K3's shared Safe address to the BNB Smart Chain `k3-capital` entity
- allows Lite's governance/entity verification to match the K3 bStock vault governors and EulerRouter governors introduced by #713
- uses the same `K3 Fireblocks wallet` label already present for this address on Monad and Arbitrum

## Onchain verification

The added address is the live `governorAdmin` for all 14 K3 bStock EVaults and the live governor for all seven associated EulerRouters on BNB Smart Chain.

Compared this Safe on every network where the same address is currently labelled: Ethereum, BNB Smart Chain, Monad, Arbitrum One, and Plasma.

- threshold: `1` on all five networks
- owners: the same two EOAs on all five networks
- modules: none on all five networks
- guard: zero address on all five networks
- fallback handler: identical on all five networks
- Safe proxy runtime: identical on all five networks
- implementation: Ethereum uses Safe 1.4.1; the other networks use SafeL2 1.4.1

This is consistently 1-of-2 across the compared networks, not 1-of-1 elsewhere versus 1-of-2 on BSC.

## Verification

- `npm run verify`
- `npm run biome`
- `git diff --check`
