### PR TITLE
fix: block bStocks in restricted countries

### DIFF
--- a/all/assets.json
+++ b/all/assets.json
@@ -1,5 +1,30 @@
 [
 	{
+		"symbols": ["SPCXB", "MSFTB", "MUB", "NVDAB", "QQQB", "SNDKB", "SPYB"],
+		"block": ["CA", "US", "GU", "MP", "PR", "VI", "AS", "UM"],
+		"restricted": [
+			"EEA",
+			"GB",
+			"GG",
+			"JE",
+			"IM",
+			"GI",
+			"AX",
+			"AE",
+			"AU",
+			"BH",
+			"HK",
+			"ID",
+			"JP",
+			"KZ",
+			"NZ",
+			"PH",
+			"SG",
+			"TH",
+			"TR"
+		]
+	},
+	{
 		"nameRegex": "^ondo($| )|\\(ondo tokenized\\)",
 		"block": ["CA", "US"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]


### PR DESCRIPTION
## Summary

- adds one asset-level geo rule for the seven Binance bStocks used by the K3 products
- applies the rule by exact symbols: `SPCXB`, `MSFTB`, `MUB`, `NVDAB`, `QQQB`, `SNDKB`, and `SPYB`
- hard-blocks Canada, the United States, and the enumerated U.S. territories
- soft-restricts the EEA and the supplied securities-marketing jurisdictions
- preserves the explicit product-level `CA` / `US` blocks on all seven K3 products, matching the Sentora Ondo and Cassa RWA convention

## Policy mapping

### Implicit app-level sanctions block

Lite's `SANCTIONED_COUNTRIES` already hard-blocks Cuba (`CU`), Iran (`IR`), and North Korea (`KP`) for every asset. They are intentionally not duplicated in this asset rule.

### Asset-level hard block

- Canada: `CA`
- United States: `US`
- Guam: `GU`
- Northern Mariana Islands: `MP`
- Puerto Rico: `PR`
- U.S. Virgin Islands: `VI`
- American Samoa: `AS`
- United States Minor Outlying Islands: `UM`

### Asset-level soft restriction

- `EEA` alias: EU27 plus Iceland, Liechtenstein, and Norway
- explicit jurisdictions: `GB`, `GG`, `JE`, `IM`, `GI`, `AX`, `AE`, `AU`, `BH`, `HK`, `ID`, `JP`, `KZ`, `NZ`, `PH`, `SG`, `TH`, `TR`

The supplied source wording says `United Arab Emirates (excluding ADGM)`. Lite's country signal cannot distinguish ADGM from the rest of the UAE, so this rule conservatively restricts all of `AE`.

## Endpoint / screenshot reconciliation

The live Binance country-matrix response and supplied legal screenshot overlap substantially but are not identical.

After expanding `EEA` and the screenshot's U.S. territories:

- shared: 48 jurisdictions
- screenshot-only non-territory codes: `BH`, `GI`, `KZ`, `SG`
- endpoint-only codes: `CA`, `RU`, `UA`
- the endpoint represents the U.S. and its territories as one `US` row; the screenshot enumerates `GU`, `MP`, `PR`, `VI`, `AS`, and `UM`

Policy resolution:

- `CA` is hard-blocked per explicit instruction
- `RU` is already hard-blocked by Lite's global sanctions layer
- `UA` is not added because the endpoint refers to Crimea, Donetsk, and Luhansk, while country-level detection would block all Ukraine and the screenshot does not list Ukraine
- screenshot-specific `BH`, `GI`, `KZ`, and `SG` remain soft-restricted

## Why asset-level plus product-level

Lite ORs asset-level rules from `all/assets.json` into vault/product geo decisions. The asset rule follows these bStocks wherever they appear. The explicit K3 product `CA` / `US` rules are retained as a product-level floor and to match the existing Sentora Ondo and Cassa RWA convention.

## Verification

- asset rule: 7 exact bStock symbols
- hard block: 8 country/territory codes
- soft restriction: `EEA` plus 18 explicit codes
- sanctioned `CU`, `IR`, and `KP` are absent from the asset rule and present in Lite's global sanctions list
- all seven K3 products retain exactly `block: ["CA", "US"]`
- `npm run verify`
- `npm run biome`
- `git diff --check`