### PR TITLE
fix: align RWA issuer geo rules

### DIFF
--- a/all/assets.json
+++ b/all/assets.json
@@ -31,13 +31,31 @@
 	},
 	{
 		"nameRegex": "xstock",
-		"block": ["CA", "US"],
+		"block": [
+			"CA",
+			"US",
+			"GU",
+			"MP",
+			"PR",
+			"VI",
+			"AS",
+			"UM",
+			"HT",
+			"MZ",
+			"NG",
+			"PH"
+		],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
 	},
 	{
 		"nameRegex": "uspc",
-		"block": ["CA", "US"],
+		"block": ["CA", "US", "GU", "MP", "PR", "VI", "AS", "UM", "VG"],
 		"restricted": ["EU", "EFTA", "BR", "HK", "MY", "SG", "GB"]
+	},
+	{
+		"nameRegex": "reusd",
+		"block": ["US", "GU", "MP", "PR", "VI", "AS", "UM", "CI", "LR"],
+		"restricted": ["CA", "VG", "CH"]
 	},
 	{
 		"nameRegex": "^(wrapped )?backed ",


### PR DESCRIPTION
## Summary

- aligns RWA asset geo rules with issuer restrictions
- adds missing coverage for reUSD, USPC, and xStocks

## Verification

- `npm run verify`
- `npm run biome`
